### PR TITLE
Showing code references for steps in js files

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "Languages"
   ],
   "activationEvents": [
-    "onLanguage:markdown"
+    "workspaceContains:**/manifest.json"
   ],
   "icon": "images/gauge-icon.png",
   "galleryBanner": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,35 +2,40 @@
 
 import * as path from 'path';
 
-import { workspace, Disposable, ExtensionContext } from 'vscode';
-import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind } from 'vscode-languageclient';
+import { workspace, Disposable, ExtensionContext, Uri } from 'vscode';
+import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind, Location as LSLocation, Position as LSPosition } from 'vscode-languageclient';
 import vscode = require('vscode');
 import fs = require('fs');
 
 import { execute } from "./execution/gaugeExecution"
 
 export function activate(context: ExtensionContext) {
-	if (fs.readdirSync(vscode.workspace.rootPath).includes("manifest.json")) {
-		let disposable = new LanguageClient(
-			'langserver',
-			{
-				command: 'gauge',
-				args: ["daemon", "--lsp", "--dir=" + vscode.workspace.rootPath],
-			},
-			{
-				documentSelector: ['markdown'],
-			}
-		).start();
+	let languageClient = new LanguageClient(
+		'langserver',
+		{
+			command: 'gauge',
+			args: ["daemon", "--lsp", "--dir=" + vscode.workspace.rootPath],
+		},
+		{
+			documentSelector: ['markdown'],
+		}
+	)
+	let disposable = languageClient.start();
+	context.subscriptions.push(vscode.commands.registerCommand('gauge.execute', (args) => { execute(args, false) }));
+	context.subscriptions.push(vscode.commands.registerCommand('gauge.execute.inParallel', (args) => { execute(args, true) }));
+	context.subscriptions.push(vscode.commands.registerCommand('gauge.showReferences', (uri: string, position: LSPosition, locations: LSLocation[]) => {
+		if (locations && locations.length > 0) {
+			vscode.commands.executeCommand('editor.action.showReferences', Uri.parse(uri), languageClient.protocol2CodeConverter.asPosition(position),
+				locations.map(languageClient.protocol2CodeConverter.asLocation))
+		}
+	}));
+	context.subscriptions.push(disposable);
 
-		context.subscriptions.push(vscode.commands.registerCommand('gauge.execute', (args) => { execute(args, false) }));
-		context.subscriptions.push(vscode.commands.registerCommand('gauge.execute.inParallel', (args) => { execute(args, true) }));
-		context.subscriptions.push(disposable);
-
-		return {
-			extendMarkdownIt(md) {
-				md.options.html = false;
-				return md;
-			}
+	return {
+		extendMarkdownIt(md) {
+			md.options.html = false;
+			return md;
 		}
 	}
 }
+


### PR DESCRIPTION
- registered new command `gauge.showReferences`.
- extension activates if manifest.json is found in workspace.