### PR TITLE
Showing code references for steps in js files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out
 reports
 logs
 .gauge
+.idea

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "Languages"
   ],
   "activationEvents": [
-    "workspaceContains:**/manifest.json"
+    "workspaceContains:manifest.json"
   ],
   "icon": "images/gauge-icon.png",
   "galleryBanner": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "Languages"
   ],
   "activationEvents": [
-    "onLanguage:markdown"
+    "workspaceContains:**/manifest.json"
   ],
   "icon": "images/gauge-icon.png",
   "galleryBanner": {

--- a/package.json
+++ b/package.json
@@ -62,12 +62,13 @@
     "build": "npm install && vsce package",
     "update-vscode": "node ./node_modules/vscode/bin/install",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "node ./node_modules/vscode/bin/test",
+    "test": "cross-env CODE_TESTS_WORKSPACE=test/testdata/sampleProject node ./node_modules/vscode/bin/test",
     "publish": "vsce publish"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",
     "@types/node": "^6.0.52",
+    "cross-env": "^5.1.1",
     "typescript": "^2.1.5",
     "vsce": "^1.30.0",
     "vscode": "^1.1.5"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { execute } from "./execution/gaugeExecution"
 
 export function activate(context: ExtensionContext) {
 	let languageClient = new LanguageClient(
-		'langserver',
+		'Gauge Language Server',
 		{
 			command: 'gauge',
 			args: ["daemon", "--lsp", "--dir=" + vscode.workspace.rootPath],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,36 +2,41 @@
 
 import * as path from 'path';
 
-import { workspace, Disposable, ExtensionContext } from 'vscode';
-import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind } from 'vscode-languageclient';
+import { workspace, Disposable, ExtensionContext, Uri } from 'vscode';
+import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind, Location as LSLocation, Position as LSPosition } from 'vscode-languageclient';
 import vscode = require('vscode');
 import fs = require('fs');
 
 import { execute } from "./execution/gaugeExecution"
 
 export function activate(context: ExtensionContext) {
-	if (fs.readdirSync(vscode.workspace.rootPath).includes("manifest.json")) {
-		let disposable = new LanguageClient(
-			'langserver',
-			{
-				command: 'gauge',
-				args: ["daemon", "--lsp", "--dir=" + vscode.workspace.rootPath],
-			},
-			{
-				documentSelector: ['markdown'],
-			}
-		).start();
+	let languageClient = new LanguageClient(
+		'langserver',
+		{
+			command: 'gauge',
+			args: ["daemon", "--lsp", "--dir=" + vscode.workspace.rootPath],
+		},
+		{
+			documentSelector: ['markdown'],
+		}
+	)
+	let disposable = languageClient.start();
+	context.subscriptions.push(vscode.commands.registerCommand('gauge.execute', (args) => { execute(args, false) }));
+	context.subscriptions.push(vscode.commands.registerCommand('gauge.execute.inParallel', (args) => { execute(args, true) }));
+	context.subscriptions.push(vscode.commands.registerCommand('gauge.execute.failed', () => { execute(null, { rerunFailed: true }) }));
+	context.subscriptions.push(vscode.commands.registerCommand('gauge.showReferences', (uri: string, position: LSPosition, locations: LSLocation[]) => {
+		if (locations && locations.length > 0) {
+			vscode.commands.executeCommand('editor.action.showReferences', Uri.parse(uri), languageClient.protocol2CodeConverter.asPosition(position),
+				locations.map(languageClient.protocol2CodeConverter.asLocation))
+		}
+	}));
+	context.subscriptions.push(disposable);
 
-		context.subscriptions.push(vscode.commands.registerCommand('gauge.execute', (args) => { execute(args, false) }));
-		context.subscriptions.push(vscode.commands.registerCommand('gauge.execute.inParallel', (args) => { execute(args, { inParallel: true }) }));
-		context.subscriptions.push(vscode.commands.registerCommand('gauge.execute.failed', () => { execute(null, { rerunFailed: true }) }));
-		context.subscriptions.push(disposable);
-
-		return {
-			extendMarkdownIt(md) {
-				md.options.html = false;
-				return md;
-			}
+	return {
+		extendMarkdownIt(md) {
+			md.options.html = false;
+			return md;
 		}
 	}
 }
+

--- a/test/execution/execution.test.ts
+++ b/test/execution/execution.test.ts
@@ -9,7 +9,10 @@ suite('Gauge Execution Tests', () => {
 		execute(spec,false).then((status) => {
 			assert.ok(status);
 			done();
-		})
+		}, (err) => {
+            assert.ok(false,  'Error: ' + err);
+            done();
+        });
 	});
 
 	test('should execute given scenario', (done) => {
@@ -17,6 +20,9 @@ suite('Gauge Execution Tests', () => {
 		execute(spec,false).then((status) => {
 			assert.ok(status);
 			done();
-		})
+		}, (err) => {
+            assert.ok(false,  'Error: ' + err);
+            done();
+        });
 	});
 });

--- a/test/execution/execution.test.ts
+++ b/test/execution/execution.test.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 import * as path from 'path';
 import { execute } from '../../src/execution/gaugeExecution'
 

--- a/test/gauge.test.ts
+++ b/test/gauge.test.ts
@@ -3,20 +3,10 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 
 suite('Gauge Extension Tests', () => {
-	let testDataPath = path.join(__dirname, '..', '..', 'test', 'testdata', 'sampleProject');
+    let testDataPath = path.join(__dirname, '..', '..', 'test', 'testdata', 'sampleProject');
 
-	test('should activate for spec and concept files', (done) => {
-		let specFile = vscode.Uri.file(path.join(testDataPath, 'specs', 'example.spec'));
-		assert.ok((typeof vscode.extensions.getExtension('getgauge.gauge') === 'undefined') || !(vscode.extensions.getExtension('getgauge.gauge').isActive))
-		vscode.workspace.openTextDocument(specFile).then((textDocument) => {
-			return vscode.window.showTextDocument(textDocument).then(() => {
-				assert.ok(vscode.extensions.getExtension('getgauge.gauge').isActive);
-			}).then(()=> {
-				vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-				return Promise.resolve();
-			});
-		}, (err) => {
-			assert.ok(false, err)
-		}).then(() => done(), done);;
-	});
+    test('should activate when manifest file found in path', () => {
+        assert.equal(vscode.workspace.rootPath, testDataPath);
+        assert.ok(vscode.extensions.getExtension('getgauge.gauge').isActive);
+    });
 });


### PR DESCRIPTION
- registered new command `gauge.showReferences`.
- extension activates if manifest.json is found in workspace.