### PR TITLE
Error Path will now have rootPath concatenated only once #79

### DIFF
--- a/src/execution/outputChannel.ts
+++ b/src/execution/outputChannel.ts
@@ -30,12 +30,16 @@ export class OutputChannel {
 
 	public appendOutBuf(line: string) {
 		let regexes: RegExp[] = [/Specification: /, /at Object.* \(/];
-		for (var i = 0; i < regexes.length; i++) {
-			let matches = line.match(regexes[i]);
-			if (matches) {
-				line = line.replace(matches[0], matches[0] + vscode.workspace.rootPath + path.sep)
+		var lineArray = line.split("\n")
+		for (var j = 0; j < lineArray.length; j++) {
+			for (var i = 0; i < regexes.length; i++) {
+				let matches = lineArray[j].match(regexes[i]);
+				if (matches && !lineArray[j].includes(vscode.workspace.rootPath)) {
+					lineArray[j] = lineArray[j].replace(matches[0], matches[0] + vscode.workspace.rootPath + path.sep)
+				}
 			}
 		}
+		line = lineArray.join("\n")
 		this.outBuf.append(line);
 	}
 

--- a/test/execution/outputChannel.test.ts
+++ b/test/execution/outputChannel.test.ts
@@ -43,6 +43,15 @@ suite('Output Channel', () => {
 		done();
 	});
 
+	test('should not change implementation path from relative to absolute if it is already absolute', (done) => {
+		var chan = new MockVSOutputChannel();
+		var outputChannel = new OutputChannel(chan, "");
+		outputChannel.appendOutBuf("      at Object.<anonymous> (" + path.join(vscode.workspace.rootPath,"tests", "step_implementation.js:24:10") +")\n");
+
+		assert.equal(chan.read(), "      at Object.<anonymous> ("+ path.join(vscode.workspace.rootPath,"tests", "step_implementation.js:24:10)"));
+		done();
+	});
+
 	test('should convert implementation path from relative to absolute for lamda methods', (done) => {
 		var chan = new MockVSOutputChannel();
 		var outputChannel = new OutputChannel(chan, "");


### PR DESCRIPTION
Error Path had two issues
1. Root Path was getting concatenated twice in some cases
2. Root Path was not getting concatenated in some cases

Fix has 2 components
1. Check if rootPath is already present in the filePath and if present don't add again
2. Regex was only modifying the first fine in a multi line stacktrace which is changed now