### PR TITLE
Spec explorer to refresh on file move and deletion #111

### DIFF
--- a/src/explorer/specExplorer.ts
+++ b/src/explorer/specExplorer.ts
@@ -12,7 +12,9 @@ export class SpecNodeProvider implements vscode.TreeDataProvider<GaugeNode> {
 	readonly onDidChangeTreeData: vscode.Event<GaugeNode | undefined> = this._onDidChangeTreeData.event;
 
 	constructor(private workspaceRoot: string, private languageClient: LanguageClient) {
-		vscode.workspace.onDidSaveTextDocument(() => this.refresh());
+		vscode.workspace.onDidChangeTextDocument(() => this.refresh());
+		vscode.workspace.onDidChangeWorkspaceFolders(() => this.refresh());
+		vscode.workspace.onDidCloseTextDocument(() => this.refresh());
 	}
 
 	refresh(element? : GaugeNode): void {


### PR DESCRIPTION
* Vscode closes a file when it is deleted or moved hence file close event is captured and spec explorer refreshed
* When a new folder is added to the workspace spec explorer should reflect that