### PR TITLE
Debugger for python added, getgauge/gauge-python#33

### DIFF
--- a/src/execution/debug.ts
+++ b/src/execution/debug.ts
@@ -1,0 +1,64 @@
+'use strict';
+
+import { window, workspace, debug } from 'vscode';
+import getPort = require('get-port');
+
+const PYTHON_DEBUG_TIMEOUT = 1500;
+const PYTHON_LANGUAGE_ID = "python";
+const JAVASCRIPT_LANGUAGE_ID = "javascript";
+
+export let clientLanguageMap: Map<string, string> = new Map();
+
+export function setDebugConf(config: any, debugPort: string): Thenable<any> {
+    let env = Object.create(process.env);
+    if (config.debug) {
+        env.DEBUGGING = true;
+        return getPort({ port: debugPort}).then((port) => {
+            env.DEBUG_PORT = port;
+            setLanguageDebugConf(clientLanguageMap.get(config.projectRoot), port, config.projectRoot);
+            return env;
+        });
+    } else {
+        return Promise.resolve(env);
+    }
+}
+
+function setLanguageDebugConf(language: string, port: number, projectRoot: string): void {
+    switch (language) {
+        case JAVASCRIPT_LANGUAGE_ID: {
+            setNodeDebugConf(port, projectRoot);
+            break;
+        }
+        case PYTHON_LANGUAGE_ID: {
+            setPythonDebugConf(port, projectRoot);
+            break;
+        }
+    }
+}
+
+function setPythonDebugConf(port: number, projectRoot: string): void {
+    let debugConfig = {
+        type: "python",
+        name: "Gauge Debugger",
+        request: "attach",
+        port: port,
+        localRoot: projectRoot
+    };
+    setTimeout(() => {
+        debug.startDebugging(workspace.getWorkspaceFolder(window.activeTextEditor.document.uri),
+        debugConfig);
+    }, PYTHON_DEBUG_TIMEOUT);
+}
+
+function setNodeDebugConf(port: number, projectRoot: string): void {
+    let debugConfig = {
+        type: "node",
+        name: "Gauge Debugger",
+        request: "attach",
+        port: port,
+        protocol: "inspector"
+    };
+
+    debug.startDebugging(workspace.getWorkspaceFolder(window.activeTextEditor.document.uri),
+    debugConfig);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -215,8 +215,6 @@ function startServerFor(folder: WorkspaceFolder) {
     if (!fs.existsSync(path.join(folder.uri.fsPath, "manifest.json"))) {
         return;
     }
-    let language = JSON.parse(fs.readFileSync(path.join(folder.uri.fsPath, "manifest.json"), 'utf8')).Language;
-    clientLanguageMap.set(folder.uri.fsPath, language);
     let serverOptions = {
         command: 'gauge',
         args: ["daemon", "--lsp", "--dir=" + folder.uri.fsPath],
@@ -239,6 +237,18 @@ function startServerFor(folder: WorkspaceFolder) {
     registerDynamicFeatures(languageClient);
     clients.set(folder.uri.fsPath, languageClient);
     languageClient.start();
+
+    languageClient.onReady().then(() => {setLanguageId(languageClient, folder.uri.fsPath); });
+}
+
+function setLanguageId(languageClient: LanguageClient, folder: string) {
+    languageClient.sendRequest("gauge/getRunnerLanguage", new CancellationTokenSource().token).then(
+        (language: string) => {
+            console.log(language);
+            clientLanguageMap.set(folder, language);
+        }
+    );
+
 }
 
 function registerDynamicFeatures(languageClient: LanguageClient) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import { getGaugeVersionInfo, GaugeVersionInfo } from './gaugeVersion';
 import { WelcomePageProvider } from './welcome/welcome';
 import { ExtractConceptCommandProvider } from './refactor/extractConcept';
 import { GenerateStubCommandProvider} from './annotator/generateStub';
+import { clientLanguageMap } from './execution/debug';
 
 const DEBUG_LOG_LEVEL_CONFIG = 'enableDebugLogs';
 const GAUGE_LAUNCH_CONFIG = 'gauge.launch';
@@ -45,7 +46,6 @@ let treeDataProvider: Disposable = new Disposable(() => undefined);
 let clients: Map<string, LanguageClient> = new Map();
 let outputChannel: OutputChannel = window.createOutputChannel('gauge');
 let specExplorerActiveFolder: string = "";
-export let clientLanguageMap: Map<string, string> = new Map();
 
 export function activate(context: ExtensionContext) {
     let gaugeVersionInfo = getGaugeVersionInfo();
@@ -241,11 +241,10 @@ function startServerFor(folder: WorkspaceFolder) {
     languageClient.onReady().then(() => {setLanguageId(languageClient, folder.uri.fsPath); });
 }
 
-function setLanguageId(languageClient: LanguageClient, folder: string) {
+function setLanguageId(languageClient: LanguageClient, projectRoot: string) {
     languageClient.sendRequest("gauge/getRunnerLanguage", new CancellationTokenSource().token).then(
         (language: string) => {
-            console.log(language);
-            clientLanguageMap.set(folder, language);
+            clientLanguageMap.set(projectRoot, language);
         }
     );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,7 @@ let treeDataProvider: Disposable = new Disposable(() => undefined);
 let clients: Map<string, LanguageClient> = new Map();
 let outputChannel: OutputChannel = window.createOutputChannel('gauge');
 let specExplorerActiveFolder: string = "";
+export let clientLanguageMap: Map<string, string> = new Map();
 
 export function activate(context: ExtensionContext) {
     let gaugeVersionInfo = getGaugeVersionInfo();
@@ -214,6 +215,8 @@ function startServerFor(folder: WorkspaceFolder) {
     if (!fs.existsSync(path.join(folder.uri.fsPath, "manifest.json"))) {
         return;
     }
+    let language = JSON.parse(fs.readFileSync(path.join(folder.uri.fsPath, "manifest.json"), 'utf8')).Language;
+    clientLanguageMap.set(folder.uri.fsPath, language);
     let serverOptions = {
         command: 'gauge',
         args: ["daemon", "--lsp", "--dir=" + folder.uri.fsPath],


### PR DESCRIPTION
* sleep added specifically for python since python debug server needs to be up before vscode tries to connect to it
* extracting language from manifest.json since the type field in debug configuration depends on the language