### PR TITLE
Showing gauge install instruction on welcome page when gauge is not installed

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,7 +32,7 @@ export enum GaugeVSCodeCommands {
     SwitchProject = 'gauge.specexplorer.switchProject',
     QuickPickOnExecution = 'gauge.quickPick.onExecution.open',
     ExtractConcept = 'gauge.extract.concept',
-    CreateAndSendTextToInstallTerminal = "gauge.createAndSendText.terminal"
+    ExecuteInTerminal = "gauge.executeIn.terminal"
 }
 
 export enum GaugeCommands {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,7 +31,8 @@ export enum GaugeVSCodeCommands {
     RepeatExecution = 'gauge.execute.repeat',
     SwitchProject = 'gauge.specexplorer.switchProject',
     QuickPickOnExecution = 'gauge.quickPick.onExecution.open',
-    ExtractConcept = 'gauge.extract.concept'
+    ExtractConcept = 'gauge.extract.concept',
+    CreateAndSendTextToInstallTerminal = "gauge.createAndSendText.terminal"
 }
 
 export enum GaugeCommands {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,9 +62,6 @@ export function activate(context: ExtensionContext) {
 
     let gaugeVersionInfo = getGaugeVersionInfo();
     if (!gaugeVersionInfo || !gaugeVersionInfo.isGreaterOrEqual(MINIMUM_SUPPORTED_GAUGE_VERSION)) {
-        notifyToInstallGauge(
-            `Cannot find 'gauge' executable or a compatible version (>=${MINIMUM_SUPPORTED_GAUGE_VERSION}) in PATH.`
-        );
         return;
     }
     languages.setLanguageConfiguration('gauge', {

--- a/src/terminal/terminal.ts
+++ b/src/terminal/terminal.ts
@@ -1,0 +1,24 @@
+import { Disposable, window, ExtensionContext, commands, Terminal } from "vscode";
+import { GaugeVSCodeCommands } from "../constants";
+
+let terminalStack: Terminal[] = [];
+
+export class TerminalProvider extends Disposable {
+    private readonly _context: ExtensionContext;
+    private readonly _disposable: Disposable;
+    constructor(context: ExtensionContext) {
+        super(() => this.dispose());
+        this._context = context;
+        this._disposable = Disposable.from(
+            commands.registerCommand(GaugeVSCodeCommands.ExecuteInTerminal, (text: string) => {
+                terminalStack.push(window.createTerminal('gauge install'));
+                getLatestTerminal().show();
+                getLatestTerminal().sendText(text);
+            }
+        ));
+    }
+}
+
+function getLatestTerminal() {
+    return terminalStack[terminalStack.length - 1];
+}

--- a/src/ui/welcome/index.html
+++ b/src/ui/welcome/index.html
@@ -9,7 +9,8 @@
 			--button-hover-background: rgba(0,0,0,0.1);
 			--inversion: 1; /* logo is white background, light themes need an inversion */
 			--header-colour: #555555;
-			--command-background : rgba(255,255,255,0.08);
+			--command-background : rgba(0,0,0,0.08);
+			--command-text-color : black;
 		}
 		.vscode-dark{
 			--button-background: rgba(255,255,255,0.08);
@@ -17,6 +18,7 @@
 			--inversion: 0;
 			--header-colour: #e0b009;
 			--command-background : black;
+			--command-text-color : white;
 		}
 		html {
 			margin:    0 auto;
@@ -70,7 +72,7 @@
 		.intro{
 			font-size: 0.8em;
 		}
-		a{
+		a {
 			outline: none;
 			text-decoration: none;
 			color: var(--color) !important;
@@ -161,21 +163,14 @@
 			align-items: center;
 			border-radius: 10px;
 			padding: 10px 20px 10px 20px;
-			/* background-color: #9a363e; */
-			/* background : repeating-linear-gradient(
-						45deg,
-						#852c34,
-						#852c34 10px,
-						#822929 10px,
-						#822929 20px
-					); */
 			border:1px solid red;
 		}
 		.link {
-			color: #66b6eb
+			color: #66b6eb;
 		}
 		.command pre {
 			width: 90%;
+			color: var(--command-text-color);
 		}
 		.command a {
 			width: 10%;
@@ -186,6 +181,17 @@
 		}
 		.fa-hashtag {
 			padding-right: 10px;
+		}
+		.run {
+			border: 1px solid green;
+			background-color: green;
+			border-radius: 0.25em;
+			padding-right: 0.25em;
+			padding-left: 0.25em;
+			color:white;
+		}
+		.text {
+			font-size: 0.75em;
 		}
 	</style>
 	<link rel="stylesheet" href="{{root}}/css/fontawesome-all.min.css"/>
@@ -208,15 +214,15 @@
 		<div class="intro">Gauge is a fast light-weight cross-platform test automation tool.</div>
 	</section>
 	<section>
-		<span class="error"><i class="fas fa-exclamation-circle"></i>Gauge not installed! </span><a href="#" class="installError"><span class="error">Read more.</span></a>
+		<span class="error"><i class="fas fa-exclamation-circle"></i>Gauge executable not found! </span><a href="#" class="installError"><span class="link">Read more.</span></a>
 		<ul>
 			<li>
 				<div class="instructions hidden">
 					<ul>
-						<li><span>Install gauge using the following instruction:</span></li>
+						<li><div class="text">Install gauge using the following instruction:</div></li>
 						<li><h4>{{name}}</h4></li>
-						<li class="command"><pre>{{command}}</pre><a id="execute" href="{{installCommand}}"><i class="fas fa-play link"></i></a></li>
-						<li><span>For other installation options <a href="https://gauge.org/get-started.html"><span class="link">click here.</span></a></span></li>
+						<li class="command"><pre>{{command}}</pre><a id="execute" href="{{installCommand}}"><span class="run">Run</span></a></li>
+						<li><div class="text">For other installation options <a href="https://gauge.org/get-started.html"><span class="link">click here.</span></a></div></li>
 					</ul>
 				</div>
 			</li>

--- a/src/ui/welcome/index.html
+++ b/src/ui/welcome/index.html
@@ -33,14 +33,14 @@
 				"sidebar	content		content"
 				"sidebar 	footer		footer";
 		}
-		h3, .sidebar h5 {
+		h3, .sidebar h5, .content h4{
 			color: var(--header-colour);
 			font-weight: normal;
 		}
 		.main-header {
 			grid-area: header;
 			text-align: center;
-			padding-bottom: 3em;
+			padding-bottom: 2em;
 			padding-top: 2em;
 			height: 20%;
 		}
@@ -136,7 +136,7 @@
 		}
 		.error {
 			color: red;
-			font-size: 20px;
+			font-size: 18px;
 			align-content: left;
 		}
 		.error i.fas {
@@ -184,6 +184,9 @@
 		pre::before {
 			content: '$ ';
 		}
+		.fa-hashtag {
+			padding-right: 10px;
+		}
 	</style>
 	<link rel="stylesheet" href="{{root}}/css/fontawesome-all.min.css"/>
 </head>
@@ -201,8 +204,8 @@
 </div>
 <main class="content">
 	<section>
-		<h3>About</h3>
-		<div class="intro">Gauge is a light-weight cross-platform test automation tool with the ability to author test cases in the business language.</div>
+		<h4>About</h4>
+		<div class="intro">Gauge is a fast light-weight cross-platform test automation tool.</div>
 	</section>
 	<section>
 		<span class="error"><i class="fas fa-exclamation-circle"></i>Gauge not installed! </span><a href="#" class="installError"><span class="error">Read more.</span></a>
@@ -210,17 +213,17 @@
 			<li>
 				<div class="instructions hidden">
 					<ul>
-						<li>Install gauge using the following instruction:</li>
-						<li><h3>{{name}}</h3></li>
+						<li><span>Install gauge using the following instruction:</span></li>
+						<li><h4>{{name}}</h4></li>
 						<li class="command"><pre>{{command}}</pre><a id="execute" href="{{installCommand}}"><i class="fas fa-play link"></i></a></li>
-						<li>For other installation options <a href="https://gauge.org/get-started.html"><span class="link">click here.</span></a></li>
+						<li><span>For other installation options <a href="https://gauge.org/get-started.html"><span class="link">click here.</span></a></span></li>
 					</ul>
 				</div>
 			</li>
 		</ul>
 	</section>
 	<section>
-		<h3>Project/Workspace</h3>
+		<h4>Project/Workspace</h4>
 		<ul>
 			<li>
 				<a class="action" href="command:gauge.execute.specification.all">
@@ -236,7 +239,7 @@
 		</ul>
 	</section>
 	<section>
-		<h3>Customize</h3>
+		<h4>Customize</h4>
 		<ul>
 			<li>
 				<a class="action" href="command:workbench.action.openGlobalSettings">
@@ -252,7 +255,7 @@
 		</ul>
 	</section>
 	<section>
-		<h3>Learn</h3>
+		<h4>Learn</h4>
 		<ul>
 			<li>
 				<a class="action" href="command:workbench.action.showCommands">
@@ -261,6 +264,17 @@
 						<div>Find and run all Gauge commands</div>
 						<span class="detail" title="Find and access Gauge commands from the Command Palette">
 							Search for <pre>gauge</pre> in the Command Pallette.
+						</span>
+					</span>
+				</a>
+			</li>
+			<li>
+				<a class="action" href="https://docs.gauge.org/longstart.html#gauge-terminologies">
+					<i class="fas fa-hashtag"></i>
+					<span>
+						<div>Open Gauge terminologies reference</div>
+						<span class="detail" title="Open gauge terminologies reference.">
+							Learn the gauge terminologies.
 						</span>
 					</span>
 				</a>
@@ -291,6 +305,9 @@
 			</li>
 			<li>
 				<a href="https://getgauge-examples.github.io/">Examples</a>
+			</li>
+			<li>
+				<a href="https://blog.getgauge.io/">Blogs</a>
 			</li>
 			<li>
 				<a href="https://docs.gauge.org/howto/index.html">HowTo?</a>

--- a/src/ui/welcome/index.html
+++ b/src/ui/welcome/index.html
@@ -9,12 +9,14 @@
 			--button-hover-background: rgba(0,0,0,0.1);
 			--inversion: 1; /* logo is white background, light themes need an inversion */
 			--header-colour: #555555;
+			--command-background : rgba(255,255,255,0.08);
 		}
 		.vscode-dark{
 			--button-background: rgba(255,255,255,0.08);
 			--button-hover-background: rgba(255,255,255,0.1);
 			--inversion: 0;
 			--header-colour: #e0b009;
+			--command-background : black;
 		}
 		html {
 			margin:    0 auto;
@@ -132,6 +134,56 @@
 		.hidden {
 			display: none;
 		}
+		.error {
+			color: red;
+			font-size: 20px;
+			align-content: left;
+		}
+		.error i.fas {
+			margin-right: 0.25em;
+			font-size: 1em;
+		}
+		#execute i.fas {
+			margin-left: 1em;
+			font-size: 1em;
+		}
+		.command {
+			display: flex;
+			justify-content: left;
+			align-items: center;
+			padding: 5px;
+			background-color:	var(--command-background);
+			color:white;
+			padding: 10px 20px 10px 20px;
+		}
+		.instructions {
+			justify-content: left;
+			align-items: center;
+			border-radius: 10px;
+			padding: 10px 20px 10px 20px;
+			/* background-color: #9a363e; */
+			/* background : repeating-linear-gradient(
+						45deg,
+						#852c34,
+						#852c34 10px,
+						#822929 10px,
+						#822929 20px
+					); */
+			border:1px solid red;
+		}
+		.link {
+			color: #66b6eb
+		}
+		.command pre {
+			width: 90%;
+		}
+		.command a {
+			width: 10%;
+			float: right;
+		}
+		pre::before {
+			content: '$ ';
+		}
 	</style>
 	<link rel="stylesheet" href="{{root}}/css/fontawesome-all.min.css"/>
 </head>
@@ -151,6 +203,21 @@
 	<section>
 		<h3>About</h3>
 		<div class="intro">Gauge is a light-weight cross-platform test automation tool with the ability to author test cases in the business language.</div>
+	</section>
+	<section>
+		<span class="error"><i class="fas fa-exclamation-circle"></i>Gauge not installed! </span><a href="#" class="installError"><span class="error">Read more.</span></a>
+		<ul>
+			<li>
+				<div class="instructions hidden">
+					<ul>
+						<li>Install gauge using the following instruction:</li>
+						<li><h3>{{name}}</h3></li>
+						<li class="command"><pre>{{command}}</pre><a id="execute" href="{{installCommand}}"><i class="fas fa-play link"></i></a></li>
+						<li>For other installation options <a href="https://gauge.org/get-started.html"><span class="link">click here.</span></a></li>
+					</ul>
+				</div>
+			</li>
+		</ul>
 	</section>
 	<section>
 		<h3>Project/Workspace</h3>
@@ -256,6 +323,19 @@
 <script>
 	document.getElementById('doNotShow').addEventListener('click', function(){
 		document.getElementById('toggleWelcome').click();
+	});
+
+	var els = document.getElementsByClassName('installError');
+	Array.prototype.forEach.call(els, function(el) {
+		el.addEventListener('click', function(){
+			this.parentNode
+				.getElementsByClassName('instructions')[0]
+				.classList.toggle('hidden');
+		})
+	});
+
+	document.getElementById("execute").addEventListener('click', function(){
+		document.getElementById
 	});
 </script>
 </body>

--- a/src/welcome/welcome.ts
+++ b/src/welcome/welcome.ts
@@ -73,7 +73,7 @@ export class WelcomePageProvider extends Disposable implements TextDocumentConte
 
     replaceText(text: string, rootPath: string): string {
         let supress = this._context.globalState.get<Boolean>(GAUGE_SUPPRESS_WELCOME);
-        let replace = [{key : /{{installCommand}}/g, value : encodeURI('command:gauge.createAndSendText.terminal?' +
+        let replace = [{key : /{{installCommand}}/g, value : encodeURI('command:gauge.executeIn.terminal?' +
                         JSON.stringify([this.getInstallCommandBasedOnOS().command]))},
                         {key : /{{name}}/g, value : this.getInstallCommandBasedOnOS().name},
                         {key : /{{command}}/g, value : this.getInstallCommandBasedOnOS().command},

--- a/src/welcome/welcome.ts
+++ b/src/welcome/welcome.ts
@@ -1,7 +1,9 @@
 import { Disposable, TextDocumentContentProvider, Uri, workspace,
     commands, ViewColumn, window, ExtensionContext } from "vscode";
 import { GaugeVSCodeCommands, VSCodeCommands } from "../constants";
+import { getGaugeVersionInfo } from '../gaugeVersion';
 import * as path from 'path';
+import { spawnSync } from 'child_process';
 
 const GAUGE_SUPPRESS_WELCOME = 'gauge.welcome.supress';
 let welcomeUri = "gauge://authority/welcome";
@@ -35,6 +37,38 @@ export class WelcomePageProvider extends Disposable implements TextDocumentConte
         return this._context.globalState.get<boolean>(GAUGE_SUPPRESS_WELCOME);
     }
 
+    getLinuxDistribution(): string {
+        let dist = spawnSync('cat', ['/etc/issue']);
+        if (dist.error) {
+            return null;
+        }
+        return dist.stdout.toString();
+    }
+
+    getInstallCommandBasedOnOS(): any {
+        let installCommand: any = {};
+        switch (process.platform) {
+            case "win32":
+                installCommand.name = "Chocolatey";
+                installCommand.command = "choco install gauge";
+                return installCommand;
+            case "darwin":
+                installCommand.name = "Brew";
+                installCommand.command = "brew install gauge";
+                return installCommand;
+            default:
+                if (this.getLinuxDistribution().indexOf("Ubuntu") !== -1) {
+                    installCommand.name = "apt-get";
+                    installCommand.command = "sudo apt-get install gauge";
+                    return installCommand;
+                } else {
+                    installCommand.name = "dnf";
+                    installCommand.command = "sudo dnf install gauge";
+                    return installCommand;
+                }
+        }
+    }
+
     async provideTextDocumentContent(uri: Uri): Promise<string> {
         let rootPath = path.join('out', uri.path);
         let docPath = Uri.file(this._context.asAbsolutePath(path.join(rootPath, 'index.html')));
@@ -42,6 +76,10 @@ export class WelcomePageProvider extends Disposable implements TextDocumentConte
         let text =  doc.getText();
         let supress = this._context.globalState.get<Boolean>(GAUGE_SUPPRESS_WELCOME);
         return text
+            .replace(/{{installCommand}}/g, encodeURI('command:gauge.createAndSendText.terminal?' +
+                    JSON.stringify([this.getInstallCommandBasedOnOS().command])))
+            .replace(/{{name}}/g, this.getInstallCommandBasedOnOS().name)
+            .replace(/{{command}}/g, this.getInstallCommandBasedOnOS().command)
             .replace(/{{doNotShowWelcome}}/g, supress ? "checked" : "")
             .replace(/{{root}}/g, Uri.file(this._context.asAbsolutePath(rootPath)).toString());
     }


### PR DESCRIPTION
When gauge binaries are not found but gauge-vscode plugin is installed, welcome page shows a section where gauge install instructions are shown based on the OS.