### PR TITLE
Welcome page enhancements #166

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,11 +59,6 @@
     ],
     "commands": [
       {
-        "command": "gauge.welcome.toggle",
-        "title": "Toggle display of Gauge Welcome page",
-        "category": "Gauge"
-      },
-      {
         "command": "gauge.stopExecution",
         "title": "Stop current gauge execution",
         "category": "Gauge",
@@ -76,7 +71,7 @@
       },
       {
         "command": "gauge.welcome",
-        "title": "Show Welcome Page",
+        "title": "Welcome",
         "category": "Gauge"
       },
       {
@@ -161,6 +156,16 @@
       "type": "object",
       "title": "Gauge configuration",
       "properties": {
+        "gauge.welcome.showOn": {
+          "type": "string",
+          "default": "upgrade",
+          "enum": [
+            "newProjectLoad",
+            "versionUpgrade",
+            "never"
+          ],
+          "description": "Shows gauge welcome page based on given value, defaulted to on upgrade."
+        },
         "gauge.specExplorer.enabled": {
           "type": "boolean",
           "default": true,
@@ -187,11 +192,6 @@
             "specs"
           ],
           "description": "List of specification directories."
-        },
-        "gauge.notification.suppressUpdateNotification": {
-          "type": "boolean",
-          "default": false,
-          "description": "Suppress information bar on gauge auto update."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,6 @@ import { clientLanguageMap } from './execution/debug';
 const DEBUG_LOG_LEVEL_CONFIG = 'enableDebugLogs';
 const GAUGE_LAUNCH_CONFIG = 'gauge.launch';
 const GAUGE_EXTENSION_ID = 'getgauge.gauge';
-const GAUGE_SUPPRESS_UPDATE_NOTIF = 'gauge.notification.suppressUpdateNotification';
 const GAUGE_VSCODE_VERSION = 'gauge.version';
 const MINIMUM_SUPPORTED_GAUGE_VERSION = '0.9.6';
 const VIEW_REPORT = "View Report";
@@ -434,8 +433,6 @@ function onConfigurationChange() {
 }
 
 function hasExtensionUpdated(context: ExtensionContext, latestVersion: string): boolean {
-    if (workspace.getConfiguration().get<boolean>(GAUGE_SUPPRESS_UPDATE_NOTIF))
-        return false;
     const gaugeVsCodePreviousVersion = context.globalState.get<string>(GAUGE_VSCODE_VERSION);
     context.globalState.update(GAUGE_VSCODE_VERSION, latestVersion);
     return !gaugeVsCodePreviousVersion || gaugeVsCodePreviousVersion === latestVersion;

--- a/src/ui/welcome/index.html
+++ b/src/ui/welcome/index.html
@@ -338,11 +338,6 @@
 		</ul>
 	</section>
 </aside>
-<footer class="main-footer">
-	<input type="checkbox" id="doNotShow" name="doNotShow" {{doNotShowWelcome}}/>
-	<label for="doNotShow">Do not show this page until the next release.</label>
-	<a href="command:gauge.welcome.toggle" class="hidden" id="toggleWelcome"/>
-</footer>
 <script>
 	document.getElementById('doNotShow').addEventListener('click', function(){
 		document.getElementById('toggleWelcome').click();

--- a/src/welcome/welcome.ts
+++ b/src/welcome/welcome.ts
@@ -1,11 +1,15 @@
 import { Disposable, TextDocumentContentProvider, Uri, workspace,
-    commands, ViewColumn, window, ExtensionContext } from "vscode";
+    commands, ViewColumn, window, ExtensionContext, TextDocument} from "vscode";
 import { GaugeVSCodeCommands, VSCodeCommands } from "../constants";
 import * as path from 'path';
 import { TerminalProvider } from "../terminal/terminal";
 import { WelcomePageTokenReplace } from "./welcomePageTokenReplace";
 
 const GAUGE_SUPPRESS_WELCOME = 'gauge.welcome.supress';
+const WELCOME_FILE_NAME = "/welcome";
+const IS_WELCOME_PAGE_OPNE = "isWelcomePageOpen";
+const HAS_OPENED_BEFORE = "hasOpenedBefore";
+
 let welcomeUri = "gauge://authority/welcome";
 
 export class WelcomePageProvider extends Disposable implements TextDocumentContentProvider {
@@ -13,7 +17,6 @@ export class WelcomePageProvider extends Disposable implements TextDocumentConte
     private readonly _disposable: Disposable;
     constructor(context: ExtensionContext, upgraded: boolean) {
         super(() => this.dispose());
-
         this._context = context;
         this._disposable = Disposable.from(
             workspace.registerTextDocumentContentProvider('gauge', this),
@@ -23,17 +26,30 @@ export class WelcomePageProvider extends Disposable implements TextDocumentConte
                 }, (reason) => {
                     window.showErrorMessage(reason);
                 });
-            }),
-            commands.registerCommand(GaugeVSCodeCommands.ToggleWelcome, () => {
-                this._context.globalState.update(GAUGE_SUPPRESS_WELCOME, !this.supressed());
             },
             new TerminalProvider(context))
         );
-        if (upgraded || !this.supressed()) {
-            let welcomePageConfig = workspace.getConfiguration('gauge.welcomePage');
-            if (welcomePageConfig && welcomePageConfig.get<boolean>('enabled')) {
+
+        workspace.onDidOpenTextDocument((doc: TextDocument) => {
+            if (doc.fileName === WELCOME_FILE_NAME) {
+                context.workspaceState.update(IS_WELCOME_PAGE_OPNE, true);
+            }
+        });
+        workspace.onDidCloseTextDocument((doc: TextDocument) => {
+            if (doc.fileName === WELCOME_FILE_NAME) {
+                context.workspaceState.update(IS_WELCOME_PAGE_OPNE, false);
+            }
+        });
+
+        let welcomePageConfig = workspace.getConfiguration('gauge.welcomePage');
+        let showWelcomePageOn = workspace.getConfiguration('gauge.welcome').get<string>('showOn');
+        if (welcomePageConfig && welcomePageConfig.get<boolean>('enabled')) {
+            if ((showWelcomePageOn === "versionUpgrade" && upgraded) ||
+            (showWelcomePageOn === "newProjectLoad" && !context.workspaceState.get(HAS_OPENED_BEFORE)) ||
+            context.workspaceState.get(IS_WELCOME_PAGE_OPNE)) {
                 commands.executeCommand(GaugeVSCodeCommands.Welcome);
             }
+            context.workspaceState.update(HAS_OPENED_BEFORE, true);
         }
     }
 

--- a/src/welcome/welcomePageTokenReplace.ts
+++ b/src/welcome/welcomePageTokenReplace.ts
@@ -40,7 +40,6 @@ export class WelcomePageTokenReplace {
                                 JSON.stringify([this.getInstallCommandBasedOnOS().command]))},
                         {key : /{{name}}/g, value : this.getInstallCommandBasedOnOS().name},
                         {key : /{{command}}/g, value : this.getInstallCommandBasedOnOS().command},
-                        {key : /{{doNotShowWelcome}}/g, value: supress ? "checked" : "" },
                         {key : /{{root}}/g, value : root}];
         replace.forEach((element) =>  {
             text = text.replace(new RegExp(element.key), element.value);

--- a/test/welcome/welcomePageTokenReplace.test.ts
+++ b/test/welcome/welcomePageTokenReplace.test.ts
@@ -12,19 +12,19 @@ suite('WelcomePage', () => {
     });
 
     test('should replace the given text with given values', (done) => {
-        let text = "name : {{name}}, command : {{command}}, doNotShowWelcome : {{doNotShowWelcome}}";
+        let text = "name : {{name}}, command : {{command}}";
         let root = "abc";
         let str = new WelcomePageTokenReplace().replaceText(text, false, root);
-        let expected = `name : choco, command : choco install gauge, doNotShowWelcome : `;
+        let expected = `name : choco, command : choco install gauge`;
         assert.equal(str, expected);
         done();
     });
 
     test('should not replace {{hello}}', (done) => {
-        let text = "name : {{hello}}, command : {{command}}, doNotShowWelcome : {{doNotShowWelcome}}";
+        let text = "name : {{hello}}, command : {{command}}";
         let root = "abc";
         let str = new WelcomePageTokenReplace().replaceText(text, false, root);
-        let expected = `name : {{hello}}, command : choco install gauge, doNotShowWelcome : `;
+        let expected = `name : {{hello}}, command : choco install gauge`;
         assert.equal(str, expected);
         done();
     });


### PR DESCRIPTION
- Removed the `Toggle display of Welcome Page`
- Removed check box `Do not show this page until the next release`
- Adde a setting `gauge.welcome.showOn` with 3 values `newProjectLoad`,  `versionUpgrade` and  `never`
