### PR TITLE
Add command to create specification template. #162

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ To override default configurations in [VSCode settings](https://code.visualstudi
 * `gauge.launch.enableDebugLogs`:  Starts gauge lsp server with log-level `debug`, defaults to `false`
 * `gauge.execution.debugPort`:  Debug port, defaults to `9229`
 * `gauge.notification.suppressUpdateNotification`:  Stops notifications for gauge-vscode plugin auto-updates, defaults to `false`
+* `gauge.create.specification.withHelp`: Crete specification template with help comments, defults to `true`
 
 # Install from source
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
         "category": "Gauge"
       },
       {
+        "command": "gauge.create.specification",
+        "title": "Create New Specification",
+        "category": "Gauge"
+      },
+      {
         "command": "gauge.config.saveRecommended",
         "title": "Optimize VS Code configuration for Gauge",
         "category": "Gauge"
@@ -148,6 +153,10 @@
     ],
     "menus": {
       "commandPalette": [
+        {
+          "command": "gauge.create.specification",
+          "when": "gauge:activated"
+        },
         {
           "command": "gauge.specexplorer.switchProject",
           "when": "false"
@@ -243,6 +252,11 @@
           "type": "int",
           "default": 9229,
           "description": "Default debug port."
+        },
+        "gauge.create.specification.withHelp": {
+          "type": "boolean",
+          "default": true,
+          "description": "When true, create the specification wtih help comments."
         }
       }
     },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,7 @@ export enum GaugeVSCodeCommands {
     ExtractConcept = 'gauge.extract.concept',
     ExecuteInTerminal = "gauge.executeIn.terminal",
     CreateProject = "gauge.createProject",
+    CreateSpecification = "gauge.create.specification",
 }
 
 export enum GaugeCommands {
@@ -68,7 +69,8 @@ export enum GaugeRequests {
     Scenarios = 'gauge/scenarios',
     Files = "gauge/getImplFiles",
     AddStub = 'gauge/putStubImpl',
-    GenerateConcept = 'gauge/generateConcept'
+    GenerateConcept = 'gauge/generateConcept',
+    SpecDirs = 'gauge/specDirs'
 }
 
 export const LAST_REPORT_PATH = 'gauge.execution.report';

--- a/src/file/specificationFileProvider.ts
+++ b/src/file/specificationFileProvider.ts
@@ -1,0 +1,87 @@
+import * as fs from "fs-extra";
+import * as path from "path";
+import { EOL } from "os";
+import { CancellationToken, Disposable, Position, Range, TextDocument, commands, window, workspace } from "vscode";
+import { CancellationTokenSource } from "vscode-languageclient";
+import { GaugeRequests, GaugeVSCodeCommands } from "../constants";
+import { GaugeWorkspace } from "../gaugeWorkspace";
+
+export class SpecificationProvider extends Disposable {
+
+    private readonly gaugeWorkspace: GaugeWorkspace;
+    private _disposable: Disposable;
+
+    constructor(workspace: GaugeWorkspace) {
+        super(() => this.dispose());
+        this.gaugeWorkspace = workspace;
+        this._disposable = Disposable.from(
+            commands.registerCommand(GaugeVSCodeCommands.CreateSpecification, () => {
+                if (this.gaugeWorkspace.getClients().size > 1) {
+                    return this.gaugeWorkspace.showProjectOptions((selection: string) => {
+                        return this.createSpecificationIn(selection);
+                    });
+                }
+                return this.createSpecificationIn(this.gaugeWorkspace.getDefaultFolder());
+            })
+        );
+    }
+
+    private createSpecificationIn(project: string): Thenable<any> {
+        let client = this.gaugeWorkspace.getClients().get(project);
+        let token = new CancellationTokenSource().token;
+        return client.sendRequest(GaugeRequests.SpecDirs, token).then((specDirs: any) => {
+            let p = "Choose the folder in which the specification should be created";
+            if (specDirs.length > 1) {
+                return window.showQuickPick(specDirs, { canPickMany: false, placeHolder: p }).then((dir: string) => {
+                    if (!dir) return;
+                    return this.getFileName(token, path.join(project, dir));
+                }, this.handleError);
+            }
+            return this.getFileName(token, path.join(project, specDirs[0]));
+
+        }, this.handleError);
+    }
+
+    private getFileName(token: CancellationToken, dir: string): Thenable<any> {
+        return window.showInputBox({ placeHolder: "Enter the file name" }, token).then((file) => {
+            if (!file) return;
+            let filename = path.join(dir, file + ".spec");
+            if (fs.existsSync(filename)) return this.handleError("File" + filename + " already exists.");
+            return this.createFileAndShow(filename);
+        }, this.handleError);
+    }
+
+    private createFileAndShow(filename: string): Thenable<any> {
+        let info = this.getDocumentInfo();
+        return fs.createFile(filename).then(() => {
+            return fs.writeFile(filename, info.text, "UTF-8").then(() => {
+                return workspace.openTextDocument(filename).then((doc: TextDocument) => {
+                    return window.showTextDocument(doc, { selection: info.range });
+                }, this.handleError);
+            }, this.handleError);
+        }, this.handleError);
+    }
+
+    private getDocumentInfo(): { text: string, range: Range } {
+        let withHelp = workspace.getConfiguration("gauge").get("create.specification.withHelp");
+        let text = "# SPECIFICATION HEADING" + EOL;
+        if (withHelp) {
+            text += EOL + "This is an executable specification file. This file follows markdown syntax." + EOL +
+                "Every heading in this file denotes a scenario. Every bulleted point denotes a step." + EOL + EOL +
+                "> To turn off these comments, set the configuration" +
+                "`gauge.create.specification.withHelp` to false." + EOL;
+        }
+        text += EOL + "## SCEANRIO HEADING" + EOL + EOL + "* step" + EOL;
+        let line = text.split(EOL).length - 2;
+        let range = new Range(new Position(line, 2), new Position(line, 6));
+        return { text: text, range: range };
+    }
+
+    handleError(message: string): Thenable<any> {
+        return window.showErrorMessage('Unable to generate speccification. ' + message);
+    }
+
+    dispose() {
+        this._disposable.dispose();
+    }
+}

--- a/src/ui/welcome/index.html
+++ b/src/ui/welcome/index.html
@@ -248,6 +248,17 @@
 					</span>
 				</a>
 			</li>
+			<li>
+				<a class="action {{activated}}" href="command:gauge.create.specification">
+					<i class="fas fa-plus"></i>
+					<span>
+						<div>Create New Specification</div>
+						<span class="detail" title="Create New Specification">
+							Create a new specification in this project.
+						</span>
+					</span>
+				</a>
+			</li>
 		</ul>
 	</section>
 	<section>

--- a/test/pages/welcome.test.ts
+++ b/test/pages/welcome.test.ts
@@ -12,4 +12,12 @@ suite('Welcome Page', () => {
         assert.ok(workspace.textDocuments.some((d) => !d.isClosed && d.uri.toString() === WELCOME_PAGE_URI),
             "Expected one document to have welcome page");
     });
+
+    test.only('should have a link to create a new specification', async () => {
+        await commands.executeCommand(GaugeVSCodeCommands.Welcome);
+        const docs = workspace.textDocuments;
+        let welcomePage = docs.find((d) => d.uri.toString() === WELCOME_PAGE_URI);
+        assert.ok(welcomePage, "Expected one document to have welcome page");
+        assert.ok(welcomePage.getText().includes("Create New Specification"));
+    });
 });


### PR DESCRIPTION
The specification can be created from the welcome page as well.
The help comments in the template can be turned off via config settings.