### PR TITLE
Added Support nested gauge project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "onCommand:gauge.createProject",
     "onCommand:gauge.welcome",
     "onCommand:gauge.help.reportIssue",
-    "workspaceContains:**/manifest.json"
+    "workspaceContains:**/manifest.json",
+    "onLanguage:gauge"
   ],
   "icon": "images/gauge-icon.png",
   "galleryBanner": {

--- a/package.json
+++ b/package.json
@@ -152,8 +152,8 @@
         }
       },
       {
-        "command":"gauge.setGaugeProjectRoot",
-        "title":"Set gauge project",
+        "command": "gauge.setGaugeProjectRoot",
+        "title": "Set gauge project",
         "category": "Gauge"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
       },
       {
         "command": "gauge.setGaugeProjectRoot",
-        "title": "Set gauge project",
+        "title": "Configure as Gauge Project",
         "category": "Gauge"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "onCommand:gauge.createProject",
     "onCommand:gauge.welcome",
     "onCommand:gauge.help.reportIssue",
-    "workspaceContains:manifest.json"
+    "workspaceContains:**/manifest.json"
   ],
   "icon": "images/gauge-icon.png",
   "galleryBanner": {
@@ -262,6 +262,10 @@
           "type": "boolean",
           "default": true,
           "description": "When true, reference codeLenses appers in implementation files."
+        },
+        "gauge.projectsDir": {
+          "type": "array",
+          "description": "List of gauge projects in the currently opend project."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -149,6 +149,11 @@
           "light": "resources/light/icon-list.svg",
           "dark": "resources/dark/icon-list.svg"
         }
+      },
+      {
+        "command":"gauge.setGaugeProjectRoot",
+        "title":"Set gauge project",
+        "category": "Gauge"
       }
     ],
     "menus": {
@@ -204,6 +209,12 @@
         {
           "command": "gauge.specexplorer.runAllActiveProjectSpecs",
           "when": "false"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "gauge.setGaugeProjectRoot",
+          "when": "explorerResourceIsFolder"
         }
       ],
       "view/title": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,6 +38,7 @@ export enum GaugeVSCodeCommands {
     ExecuteInTerminal = "gauge.executeIn.terminal",
     CreateProject = "gauge.createProject",
     CreateSpecification = "gauge.create.specification",
+    SetGaugeProjectRoot = "gauge.setGaugeProjectRoot"
 }
 
 export enum GaugeCommands {

--- a/src/execution/gaugeExecutor.ts
+++ b/src/execution/gaugeExecutor.ts
@@ -11,6 +11,7 @@ import { GaugeDebugger } from "./debug";
 import { OutputChannel } from './outputChannel';
 import cp = require('child_process');
 import path = require('path');
+import { getGaugeProject } from '../util';
 
 const outputChannelName = 'Gauge Execution';
 const extensions = [".spec", ".md"];
@@ -124,7 +125,7 @@ export class GaugeExecutor extends Disposable {
         let activeTextEditor = window.activeTextEditor;
         if (activeTextEditor) {
             let spec = activeTextEditor.document.fileName;
-            let lc = clients.get(workspace.getWorkspaceFolder(window.activeTextEditor.document.uri).uri.fsPath);
+            let lc = clients.get(getGaugeProject(window.activeTextEditor.document.uri).uri.fsPath);
             if (!extensions.includes(path.extname(spec))) {
                 return Promise.reject(new Error(`No scenario(s) found. Current file is not a gauge specification.`));
             }
@@ -221,7 +222,7 @@ export class GaugeExecutor extends Disposable {
             }),
 
             commands.registerCommand(GaugeVSCodeCommands.Debug, (spec) => {
-                let cwd = workspace.getWorkspaceFolder(window.activeTextEditor.document.uri).uri.fsPath;
+                let cwd = getGaugeProject(window.activeTextEditor.document.uri).uri.fsPath;
                 return this.execute(spec, { inParallel: false, status: spec, projectRoot: cwd, debug: true });
             }),
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,11 @@
 'use strict';
-import * as path from 'path';
 
 import {
-    workspace, ExtensionContext, Uri, extensions, Position,
-    commands, window, CancellationTokenSource, version, languages
+    workspace, ExtensionContext, extensions, commands, window, version, languages
 } from 'vscode';
 
 import opn = require('opn');
-import { GaugeExecutor } from "./execution/gaugeExecutor";
-import { VSCodeCommands, GaugeVSCodeCommands } from './constants';
+import { GaugeVSCodeCommands } from './constants';
 import { getGaugeVersionInfo, GaugeVersionInfo } from './gaugeVersion';
 import { PageProvider } from './pages/provider';
 import { GenerateStubCommandProvider } from './annotator/generateStub';
@@ -17,7 +14,7 @@ import { GaugeState } from './gaugeState';
 import { ReferenceProvider } from './gaugeReference';
 import { ProjectInitializer } from './init/projectInit';
 import { ConfigProvider } from './config/configProvider';
-import { isGaugeProject, findGaugeProjects } from './util';
+import { findGaugeProjects, setGaugeProjectRoot } from './util';
 import { showWelcomePage } from './pages/welcome';
 
 const GAUGE_EXTENSION_ID = 'getgauge.gauge';
@@ -34,7 +31,8 @@ export function activate(context: ExtensionContext) {
         pageProvider,
         commands.registerCommand(GaugeVSCodeCommands.ReportIssue, () => {
             reportIssue(versionInfo);
-        })
+        }),
+        commands.registerCommand(GaugeVSCodeCommands.SetGaugeProjectRoot, (dir) => setGaugeProjectRoot(dir.fsPath) )
     );
 
     const gaugeProjects = findGaugeProjects(folders);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { GaugeState } from './gaugeState';
 import { ReferenceProvider } from './gaugeReference';
 import { ProjectInitializer } from './init/projectInit';
 import { ConfigProvider } from './config/configProvider';
-import { findGaugeProjects, setGaugeProjectRoot } from './util';
+import { findGaugeProjects, setGaugeProjectRoot, getProjectRootFromSpecPath } from './util';
 import { showWelcomePage } from './pages/welcome';
 
 const GAUGE_EXTENSION_ID = 'getgauge.gauge';
@@ -32,7 +32,13 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand(GaugeVSCodeCommands.ReportIssue, () => {
             reportIssue(versionInfo);
         }),
-        commands.registerCommand(GaugeVSCodeCommands.SetGaugeProjectRoot, (dir) => setGaugeProjectRoot(dir.fsPath) )
+        commands.registerCommand(GaugeVSCodeCommands.SetGaugeProjectRoot, (dir) => setGaugeProjectRoot(dir.fsPath) ),
+        window.onDidChangeActiveTextEditor( ( event ) => {
+            if (isGaugeDocument(event.document)) {
+                let proejctRoot = getProjectRootFromSpecPath(event.document.uri.fsPath);
+                setGaugeProjectRoot(proejctRoot);
+            }
+        })
     );
 
     const gaugeProjects = findGaugeProjects(folders);
@@ -53,6 +59,10 @@ export function activate(context: ExtensionContext) {
         new GenerateStubCommandProvider(clients),
         new ConfigProvider(context)
     );
+}
+
+function isGaugeDocument(document) {
+    return document.languageId === "gauge";
 }
 
 function reportIssue(gaugeVersion: GaugeVersionInfo) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ import { GaugeState } from './gaugeState';
 import { ReferenceProvider } from './gaugeReference';
 import { ProjectInitializer } from './init/projectInit';
 import { ConfigProvider } from './config/configProvider';
-import { isGaugeProject } from './util';
+import { isGaugeProject, gaugeProjectsFromConfig } from './util';
 import { showWelcomePage } from './pages/welcome';
 
 const GAUGE_EXTENSION_ID = 'getgauge.gauge';
@@ -37,13 +37,14 @@ export function activate(context: ExtensionContext) {
         })
     );
 
-    if (!folders || !folders.some(isGaugeProject)) return;
+    const projectsDir = gaugeProjectsFromConfig(workspace.getConfiguration("gauge"));
+    if (!folders || !folders.some(isGaugeProject) && !projectsDir.length) return;
     showWelcomePage(context, hasExtensionUpdated(context, currentExtensionVersion));
     if (!versionInfo || !versionInfo.isGreaterOrEqual(MINIMUM_SUPPORTED_GAUGE_VERSION)) return;
 
     languages.setLanguageConfiguration('gauge', { wordPattern: /^(?:[*])([^*].*)$/g });
 
-    let gaugeWorkspace = new GaugeWorkspace(new GaugeState(context));
+    let gaugeWorkspace = new GaugeWorkspace(new GaugeState(context), folders.length > 1 ? folders : projectsDir);
 
     let clients = gaugeWorkspace.getClients();
     pageProvider.activated = true;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ import { GaugeState } from './gaugeState';
 import { ReferenceProvider } from './gaugeReference';
 import { ProjectInitializer } from './init/projectInit';
 import { ConfigProvider } from './config/configProvider';
-import { isGaugeProject, gaugeProjectsFromConfig } from './util';
+import { isGaugeProject, findGaugeProjects } from './util';
 import { showWelcomePage } from './pages/welcome';
 
 const GAUGE_EXTENSION_ID = 'getgauge.gauge';
@@ -37,14 +37,14 @@ export function activate(context: ExtensionContext) {
         })
     );
 
-    const projectsDir = gaugeProjectsFromConfig(workspace.getConfiguration("gauge"));
-    if (!folders || !folders.some(isGaugeProject) && !projectsDir.length) return;
+    const gaugeProjects = findGaugeProjects(folders);
+    if (!gaugeProjects.length) return;
     showWelcomePage(context, hasExtensionUpdated(context, currentExtensionVersion));
     if (!versionInfo || !versionInfo.isGreaterOrEqual(MINIMUM_SUPPORTED_GAUGE_VERSION)) return;
 
     languages.setLanguageConfiguration('gauge', { wordPattern: /^(?:[*])([^*].*)$/g });
 
-    let gaugeWorkspace = new GaugeWorkspace(new GaugeState(context), folders.length > 1 ? folders : projectsDir);
+    let gaugeWorkspace = new GaugeWorkspace(new GaugeState(context), gaugeProjects );
 
     let clients = gaugeWorkspace.getClients();
     pageProvider.activated = true;

--- a/src/gaugeReference.ts
+++ b/src/gaugeReference.ts
@@ -3,7 +3,8 @@ import { GaugeVSCodeCommands, VSCodeCommands } from "./constants";
 import {
     LanguageClient, TextDocumentIdentifier, Location as LSLocation, Position as LSPosition
 } from 'vscode-languageclient';
-
+import * as path from 'path';
+import { getGaugeProject } from "./util";
 export class ReferenceProvider extends Disposable {
     private _disposable: Disposable;
     constructor(private clients: Map<string, LanguageClient>) {
@@ -20,7 +21,7 @@ export class ReferenceProvider extends Disposable {
     private showStepReferences(clients: Map<string, LanguageClient>):
     (uri: string, position: LSPosition, stepValue: string) => Thenable<any> {
     return (uri: string, position: LSPosition, stepValue: string) => {
-        let languageClient = clients.get(workspace.getWorkspaceFolder(Uri.parse(uri)).uri.fsPath);
+        let languageClient = clients.get(getGaugeProject(Uri.parse(uri)).uri.fsPath);
         return languageClient.sendRequest("gauge/stepReferences", stepValue, new CancellationTokenSource().token).then(
             (locations: LSLocation[]) => {
                 return this.showReferences(locations, uri, languageClient, position);
@@ -33,7 +34,7 @@ export class ReferenceProvider extends Disposable {
             let position = window.activeTextEditor.selection.active;
             let documentId = TextDocumentIdentifier.create(window.activeTextEditor.document.uri.toString());
             let activeEditor = window.activeTextEditor.document.uri;
-            let languageClient = clients.get(workspace.getWorkspaceFolder(activeEditor).uri.fsPath);
+            let languageClient = clients.get(getGaugeProject(activeEditor).uri.fsPath);
             let params = { textDocument: documentId, position };
             return languageClient.sendRequest("gauge/stepValueAt", params, new CancellationTokenSource().token).then(
                 (stepValue: string) => {

--- a/src/gaugeWorkspace.ts
+++ b/src/gaugeWorkspace.ts
@@ -3,7 +3,7 @@
 import * as path from 'path';
 import {
     CancellationTokenSource, Disposable, OutputChannel, WorkspaceConfiguration, WorkspaceFolder,
-    WorkspaceFoldersChangeEvent, commands, window, workspace
+    WorkspaceFoldersChangeEvent, commands, window, workspace, Uri
 } from "vscode";
 import { DynamicFeature, LanguageClient, RevealOutputChannelOn } from "vscode-languageclient";
 import { GaugeCommandContext, setCommandContext } from "./constants";
@@ -32,11 +32,10 @@ export class GaugeWorkspace extends Disposable {
     private _disposable: Disposable;
     private _specNodeProvider: SpecNodeProvider;
 
-    constructor(private state: GaugeState) {
+    constructor(private state: GaugeState, private workspaceFolders: WorkspaceFolder []) {
         super(() => this.dispose());
         this._executor = new GaugeExecutor(this);
-        workspace.workspaceFolders.forEach((folder) => this.startServerFor(folder));
-
+        workspaceFolders.forEach((folder) => this.startServerFor(folder));
         setCommandContext(GaugeCommandContext.MultiProject, this._clients.size > 1);
 
         workspace.onDidChangeWorkspaceFolders((event) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -35,6 +35,11 @@ export function findGaugeProjects( folders: WorkspaceFolder[]): WorkspaceFolder 
     });
 }
 
+export function getGaugeProject(uri: Uri): WorkspaceFolder {
+    let projects = findGaugeProjects(workspace.workspaceFolders);
+    return projects.find( (project) => !!uri.fsPath.match(project.uri.fsPath) );
+}
+
 export function setGaugeProjectRoot(absPath: string) {
     let pwd = workspace.workspaceFolders[0];
     let basePath = path.relative(pwd.uri.fsPath, absPath);

--- a/src/util.ts
+++ b/src/util.ts
@@ -36,7 +36,8 @@ export function findGaugeProjects( folders: WorkspaceFolder[]): WorkspaceFolder 
 }
 
 export function setGaugeProjectRoot(absPath: string) {
-    let basePath = path.basename(absPath);
+    let pwd = workspace.workspaceFolders[0];
+    let basePath = path.relative(pwd.uri.fsPath, absPath);
     const config = workspace.getConfiguration();
     let projectsDir = config.inspect(GAUGE_PROJECTS_DIR_CONF).workspaceValue as Array<String>;
     if (projectsDir) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,12 +1,12 @@
 'use strict';
 
 import * as path from 'path';
-import { WorkspaceFolder } from 'vscode';
+import { WorkspaceFolder, WorkspaceConfiguration, Uri, workspace } from 'vscode';
 import { existsSync, readFileSync } from 'fs';
 import { GAUGE_MANIFEST_FILE } from './constants';
 
 export function isGaugeProject(folder: WorkspaceFolder): boolean {
-    const filePath = path.join(folder.uri.fsPath, GAUGE_MANIFEST_FILE);
+    const filePath = path.join( folder.uri.fsPath, GAUGE_MANIFEST_FILE);
     if (existsSync(filePath)) {
         try {
             const content = readFileSync(filePath);
@@ -17,6 +17,16 @@ export function isGaugeProject(folder: WorkspaceFolder): boolean {
         }
     }
     return false;
+}
+
+export function gaugeProjectsFromConfig(workspaceConfig: WorkspaceConfiguration): WorkspaceFolder [] {
+    const pwd = workspace.workspaceFolders[0];
+    return workspaceConfig.projectsDir.map( (dirName) => {
+        let workspaceFolder = {
+            uri: Uri.file(path.join(pwd.uri.fsPath, dirName))
+        }  as  WorkspaceFolder;
+        return workspaceFolder;
+    });
 }
 
 export function isDotnetProject(projectRoot) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,9 +19,13 @@ export function isGaugeProject(folder: WorkspaceFolder): boolean {
     return false;
 }
 
-export function gaugeProjectsFromConfig(workspaceConfig: WorkspaceConfiguration): WorkspaceFolder [] {
-    const pwd = workspace.workspaceFolders[0];
-    return workspaceConfig.projectsDir.map( (dirName) => {
+export function findGaugeProjects( folders: WorkspaceFolder[]): WorkspaceFolder [] {
+    let gaugeProjects = [];
+    if (folders.some(isGaugeProject)) return folders;
+    let configuredGaugeProjects = workspace.getConfiguration("gauge").projectsDir;
+    if (!configuredGaugeProjects.length || folders.length > 1 ) return gaugeProjects;
+    const pwd = folders[0];
+    return configuredGaugeProjects.map( (dirName) => {
         let workspaceFolder = {
             uri: Uri.file(path.join(pwd.uri.fsPath, dirName))
         }  as  WorkspaceFolder;


### PR DESCRIPTION
gauge-vscode gets activated whenever user opens any Gauge [Spec](https://docs.gauge.org/latest/writing-specifications.html#specifications-spec) or [Concepts](https://docs.gauge.org/latest/writing-specifications.html#concept) file.

To manually configure a directory as gauge project just right click on the directory and select the **Set gauge project** option. 

**Example:**
<img width="1029" alt="configure-ftest-as-gauge-roject" src="https://user-images.githubusercontent.com/15261737/47899786-ac33a700-dea0-11e8-9cfb-840bf50eff9a.png">

Once the user does that they should see a config in the [WorkSpace Settings](https://code.visualstudio.com/docs/getstarted/settings)

**Example :**
<img width="1029" alt="screen shot 2018-11-02 at 1 05 20 pm" src="https://user-images.githubusercontent.com/15261737/47899944-2cf2a300-dea1-11e8-803a-4d27a8369770.png">

