### PR TITLE
Fix for, #319

### DIFF
--- a/src/execution/gaugeExecutor.ts
+++ b/src/execution/gaugeExecutor.ts
@@ -150,7 +150,7 @@ export class GaugeExecutor extends Disposable {
         if (config.repeat) return args.concat(`-Dflags=--repeat`);
         args = args.concat(defaultArgs);
         if (config.inParallel) args = args.concat("-DinParallel=true");
-        if (spec) return args.concat(`-DspecDirs=${spec}`);
+        if (spec) return args.concat(`-DspecsDir=${path.relative(config.projectRoot, spec)}`);
         return args;
     }
 


### PR DESCRIPTION
- Fixed typo in Gauge-maven plugin args (changed DspecDirs to DspecsDir).
- Calculate specs dir path relative to the project root.