### PR TITLE
Fix for recommended settings for Gauge projects.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,11 @@ addons:
   apt:
     packages:
       - libsecret-1-dev
+services:
+  - xvfb
 env:
   - GAUGE_TELEMETRY_ENABLED=false GAUGE_PREFIX=/tmp
 before_install:
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
-    fi
   - curl -sSfL https://raw.githubusercontent.com/getgauge/infrastructure/master/nightly_scripts/install_latest_gauge_nightly.sh | bash
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       ln -s $NVM_BIN/node /tmp/bin/node;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - linux
 language: node_js
 node_js:
-  - "9"
+  - "10"
 addons:
   apt:
     packages:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,8 @@
 {
     "version": "0.1.0",
     "configurations": [
+
+
         {
             "name": "Launch Extension",
             "type": "extensionHost",
@@ -16,7 +18,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test", "${workspaceRoot}/test/testdata/sampleProject" ],
+            "args": ["--disable-extensions", "--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test", "${workspaceRoot}/test/testdata/sampleProject" ],
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],

--- a/package.json
+++ b/package.json
@@ -278,8 +278,7 @@
     "pack": "webpack-cli --env.production",
     "build": "npm install && npm run lint && npm run compile && npm run pack && vsce package",
     "update-vscode": "node ./node_modules/vscode/bin/install",
-    "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "cross-env CODE_TESTS_WORKSPACE=test/testdata/sampleProject node ./node_modules/vscode/bin/test",
+    "test": "node out/test/runTest.js",
     "publish": "vsce publish"
   },
   "devDependencies": {
@@ -288,13 +287,16 @@
     "@types/node": "^10.12.5",
     "@types/ps-tree": "^1.1.0",
     "cross-env": "^5.2.0",
+    "glob": "^7.1.4",
+    "mocha": "^6.1.4",
     "terser-webpack-plugin": "1.1.0",
     "ts-loader": "5.3.0",
     "ts-mockito": "^2.3.1",
     "tslint": "^5.16.0",
     "typescript": "^3.1.6",
     "vsce": "1.44.0",
-    "vscode": "^1.1.33",
+    "vscode": "^1.1.36",
+    "vscode-test": "^1.2.0",
     "webpack": "4.31.0",
     "webpack-cli": "^3.1.2",
     "webpack-node-externals": "^1.7.2"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "version": "0.0.11",
   "publisher": "getgauge",
   "engines": {
-    "vscode": "1.37.1"
+    "vscode": "1.38.0"
   },
   "categories": [
     "Languages"

--- a/src/config/configProvider.ts
+++ b/src/config/configProvider.ts
@@ -18,14 +18,13 @@ export class ConfigProvider extends Disposable {
 
         this.applyDefaultSettings();
         this._disposable = commands.registerCommand(GaugeVSCodeCommands.SaveRecommendedSettings,
-            () => this.applyAndReload(this.recommendedSettings));
+            () => this.applyAndReload(this.recommendedSettings, ConfigurationTarget.Workspace));
 
         if (!this.verifyRecommendedConfig()) {
             let config = workspace.getConfiguration().inspect("gauge.recommendedSettings.options");
             if (config.globalValue === "Apply & Reload") {
-                let settings = {...this.recommendedSettings,
-                    ...{"gauge.recommendedSettings.options": "Apply & Reload"}};
-                this.applyAndReload(settings);
+                let settings = {...this.recommendedSettings};
+                this.applyAndReload(settings, ConfigurationTarget.Workspace);
                 return;
             }
             window.showInformationMessage("Gauge [recommends](https://docs.gauge.org/using.html#id31) " +
@@ -33,15 +32,17 @@ export class ConfigProvider extends Disposable {
                 "Apply & Reload", "Remind me later", "Ignore")
                 .then((option) => {
                     if (option === "Apply & Reload") {
-                        let settings = {...this.recommendedSettings,
-                            ...{"gauge.recommendedSettings.options": "Apply & Reload"}};
-                        return this.applyAndReload(settings);
+                        this.applyAndReload(this.recommendedSettings, ConfigurationTarget.Workspace, false)
+                        let settings = {"gauge.recommendedSettings.options": "Apply & Reload"};
+                        return this.applyAndReload(settings, ConfigurationTarget.Global);
                     } else if (option === "Ignore") {
-                        return this.applyAndReload({"gauge.recommendedSettings.options": "Ignore"});
+                        let settings = { "gauge.recommendedSettings.options": "Ignore" };
+                        return this.applyAndReload(settings, ConfigurationTarget.Global, false);
                     } else if (option === "Remind me later") {
                         let config = workspace.getConfiguration().inspect("gauge.recommendedSettings.options");
                         if (config.globalValue !== "Remind me later") {
-                            return this.applyAndReload({"gauge.recommendedSettings.options": "Remind me later"});
+                            let settings = { "gauge.recommendedSettings.options": "Remind me later" };
+                            return this.applyAndReload(settings, ConfigurationTarget.Global, false);
                         }
                     }
                 });
@@ -72,14 +73,15 @@ export class ConfigProvider extends Disposable {
         return true;
     }
 
-    private applyAndReload(settings: Object): Thenable<any> {
+    private applyAndReload(settings: Object, configurationTarget: number, shouldReload: boolean = true): Thenable<any> {
         let updatePromises = [];
         for (const key in settings) {
             if (settings.hasOwnProperty(key)) {
                 updatePromises.push(workspace.getConfiguration()
-                    .update(key, settings[key], ConfigurationTarget.Global));
+                    .update(key, settings[key], configurationTarget));
             }
         }
+        if (!shouldReload) return;
         return Promise.all(updatePromises).then(() => commands.executeCommand(VSCodeCommands.ReloadWindow));
     }
 

--- a/src/config/configProvider.ts
+++ b/src/config/configProvider.ts
@@ -32,7 +32,7 @@ export class ConfigProvider extends Disposable {
                 "Apply & Reload", "Remind me later", "Ignore")
                 .then((option) => {
                     if (option === "Apply & Reload") {
-                        this.applyAndReload(this.recommendedSettings, ConfigurationTarget.Workspace, false)
+                        this.applyAndReload(this.recommendedSettings, ConfigurationTarget.Workspace, false);
                         let settings = {"gauge.recommendedSettings.options": "Apply & Reload"};
                         return this.applyAndReload(settings, ConfigurationTarget.Global);
                     } else if (option === "Ignore") {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,11 +1,31 @@
-import testRunner = require('vscode/lib/testrunner');
+import * as path from 'path';
+import * as Mocha from 'mocha';
+import * as glob from 'glob';
 
-// You can directly control Mocha options by uncommenting the following lines
-// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
-testRunner.configure({
-    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
-    useColors: true, // colored output from test results
-    timeout: 5000
-});
+export function run(testsRoot: string, cb: (error: any, failures?: number) => void): void {
+    // Create the mocha test
+    const mocha = new Mocha({
+        ui: 'tdd',
+    });
+    mocha.useColors(true);
 
-module.exports = testRunner;
+    glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+        if (err) {
+            return cb(err);
+        }
+
+        // Add files to the test suite
+        files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+
+        try {
+            // Run the mocha test
+            mocha
+                .run(failures => {
+                    cb(null, failures);
+                });
+
+        } catch (err) {
+            cb(err);
+        }
+    });
+}

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -17,7 +17,8 @@ async function go() {
 
 
     } catch (err) {
-        console.error('Failed to run tests');
+        console.error('---Failed to run tests---');
+        console.error(err);
         process.exit(1);
     }
 }

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -1,0 +1,25 @@
+import * as path from 'path';
+
+
+import { runTests } from 'vscode-test';
+
+async function go() {
+    try {
+        const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+        const extensionTestsPath = path.resolve(__dirname, './');
+        const testWorkspace = path.resolve(__dirname, './testdata');
+
+        await runTests({
+            extensionDevelopmentPath,
+            extensionTestsPath,
+            launchArgs: ['--disable-extensions', `--folder-uri ${testWorkspace}`]
+        });
+
+
+    } catch (err) {
+        console.error('Failed to run tests');
+        process.exit(1);
+    }
+}
+
+go()


### PR DESCRIPTION
**Recommended settings**
```
{
      "files.autoSave": "afterDelay",
      "files.autoSaveDelay": 500
}
```
Until now Gauge VS Code used to set recommended settings for the user space.
Which made it harder for the user to work with other projects where they did not required the `autoSave` feature or needed different value for it than the `afterDelay`.

Now Gauge VS Code will set recommended settings only for the workspace instead of for the user.