### PR TITLE
Remove report issue feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ Please see below for the best place to ask a query:
 - How do I? -- [Stack Overflow](https://stackoverflow.com/questions/ask?tags=getgauge)
 - I got this error, why? -- [Stack Overflow](https://stackoverflow.com/questions/ask?tags=getgauge)
 - I got this error and I'm sure it's a bug -- file an [issue](https://github.com/getgauge/gauge-vscode/issues)
-	You can also easily report issues from VSCode itself by executing command `Gauge: Report Issue` from the command pallete
 - I have an idea/request -- file an [issue](https://github.com/getgauge/gauge-vscode/issues)
 - Why do you? -- [Google Groups](https://groups.google.com/forum/#!forum/getgauge)
 - When will you? -- [Google Groups](https://groups.google.com/forum/#!forum/getgauge)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   ],
   "activationEvents": [
     "onCommand:gauge.createProject",
-    "onCommand:gauge.help.reportIssue",
     "workspaceContains:manifest.json",
     "onLanguage:gauge"
   ],
@@ -124,11 +123,6 @@
       {
         "command": "gauge.execute.scenarios",
         "title": "Run Scenarios",
-        "category": "Gauge"
-      },
-      {
-        "command": "gauge.help.reportIssue",
-        "title": "Report Issue",
         "category": "Gauge"
       },
       {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,6 @@ export enum GaugeVSCodeCommands {
     GenerateConceptStub = 'gauge.generate.concept',
     ShowReferences = 'gauge.showReferences',
     ShowReferencesAtCursor = 'gauge.showReferences.atCursor',
-    ReportIssue = 'gauge.help.reportIssue',
     Open = 'gauge.open',
     RepeatExecution = 'gauge.execute.repeat',
     SwitchProject = 'gauge.specexplorer.switchProject',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,12 +21,6 @@ export async function activate(context: ExtensionContext) {
         return;
     }
     let folders = workspace.workspaceFolders;
-    context.subscriptions.push(
-        new ProjectInitializer(cli),
-        commands.registerCommand(GaugeVSCodeCommands.ReportIssue, () => {
-            reportIssue(cli);
-        })
-    );
     let hasGaugeProject = folders && folders.some((f) => ProjectFactory.isGaugeProject(f.uri.fsPath));
     if (!hasActiveGaugeDocument(window.activeTextEditor) && !hasGaugeProject) return;
     if (!cli.isGaugeInstalled() || !cli.isGaugeVersionGreaterOrEqual(MINIMUM_SUPPORTED_GAUGE_VERSION)) {
@@ -45,26 +39,4 @@ export async function activate(context: ExtensionContext) {
         new GenerateStubCommandProvider(clientsMap),
         new ConfigProvider(context)
     );
-}
-
-function reportIssue(cli: CLI) {
-    let extVersion = extensions.getExtension("getgauge.gauge").packageJSON.version;
-    let gaugeVersionInfo = "";
-    if (cli.isGaugeInstalled()) {
-        gaugeVersionInfo = cli.gaugeVersionString();
-    } else {
-        gaugeVersionInfo = "Gauge executable not found!!";
-    }
-    let issueTemplate = `\`\`\`
-VS-Code version: ${version}
-Gauge Extension Version: ${extVersion}
-
-${gaugeVersionInfo}
-\`\`\``;
-
-    return env.openExternal(
-        Uri.parse(encodeURI(`https://github.com/getgauge/gauge-vscode/issues/new?body=${escape(issueTemplate)}`))).then(
-        () => { }, (err) => {
-            window.showErrorMessage("Can't open issue URL. " + err);
-        });
 }


### PR DESCRIPTION
Fixes: #413 

The "Report issue" is not consistent as it
opens a browser. Plus it posts version info
with an opt in.

Remove this feature as it will be much easier
to report issues to the right repository
manually.

Also note. VS Code's "Report Issue" allows 
reporting issues with plugins.