### PR TITLE
Return proper error messages on failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -799,7 +799,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -2041,7 +2040,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {

--- a/src/execution/gaugeExecutor.ts
+++ b/src/execution/gaugeExecutor.ts
@@ -48,10 +48,10 @@ export class GaugeExecutor extends Disposable {
     }
 
     public execute(spec: string, config: ExecutionConfig): Thenable<any> {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             if (this.executing) {
-                reject(new Error('A Specification or Scenario is still running!'));
-                return;
+                window.showErrorMessage('A Specification or Scenario is still running!');
+                return resolve(undefined);
             }
             try {
                 this.executing = true;
@@ -151,14 +151,16 @@ export class GaugeExecutor extends Disposable {
         if (activeTextEditor) {
             let doc = activeTextEditor.document;
             if (!extensions.includes(extname(doc.fileName))) {
-                return Promise.reject(new Error(`No specification found. Current file is not a gauge specification.`));
+                window.showErrorMessage('No specification found. Current file is not a gauge specification.');
+                return Promise.resolve(undefined);
             }
             return this.execute(doc.fileName, new ExecutionConfig()
                 .setStatus(doc.fileName)
                 .setProject(ProjectFactory.getProjectByFilepath(doc.uri.fsPath))
             );
         } else {
-            return Promise.reject(new Error(`A gauge specification file should be open to run this command.`));
+            window.showErrorMessage('A gauge specification file should be open to run this command.');
+            return Promise.resolve(undefined);
         }
     }
 
@@ -169,7 +171,8 @@ export class GaugeExecutor extends Disposable {
             let spec = activeTextEditor.document.fileName;
             let lc = clientsMap.get(window.activeTextEditor.document.uri.fsPath).client;
             if (!extensions.includes(extname(spec))) {
-                return Promise.reject(new Error(`No scenario(s) found. Current file is not a gauge specification.`));
+                window.showErrorMessage('No scenario(s) found. Current file is not a gauge specification.');
+                return;
             }
             return this.getAllScenarios(lc, atCursor).then((scenarios: any): Thenable<any> => {
                 if (atCursor) {
@@ -178,10 +181,11 @@ export class GaugeExecutor extends Disposable {
                 return this.executeOptedScenario(scenarios);
             }, (reason: any) => {
                 window.showErrorMessage(`found some problems in ${spec}. Fix all problems before running scenarios.`);
-                return Promise.reject(reason);
+                return Promise.resolve(undefined);
             });
         } else {
-            return Promise.reject(new Error(`A gauge specification file should be open to run this command.`));
+            window.showErrorMessage('A gauge specification file should be open to run this command.');
+            return Promise.resolve(undefined);
         }
     }
 
@@ -259,7 +263,8 @@ export class GaugeExecutor extends Disposable {
                 );
             }
         }, (reason: any) => {
-            return Promise.reject(reason);
+            window.showErrorMessage(reason);
+            return Promise.resolve(undefined);
         });
     }
 


### PR DESCRIPTION
I noticed that tests were failing as follows

```
 1 failing
       should reject execution when another is already in progress:
      AssertionError [ERR_ASSERTION]: "Running the contributed command: 'gauge.execute' failed." == 'A Specification or Scenario is still running!'
      + expected - actual
      -Running the contributed command: 'gauge.execute' failed.
      +A Specification or Scenario is still running!
```

This seems to be happening because of https://github.com/getgauge/gauge-vscode/blob/59ee8cfe1fdd0428af6e4f8e95ff01802c4f4909/src/execution/gaugeExecutor.ts#L52-L54

This also does not display the custom error message for example the current version of the plugin shows

<img width="638" alt="Screenshot 2021-06-09 at 09 24 57" src="https://user-images.githubusercontent.com/54427/121320001-ab8b0900-c904-11eb-9a5e-4a147be701fe.png">


After this change

```
 if (this.executing) {
        window.showErrorMessage('A Specification or Scenario is still running!');
         return resolve(undefined);
 }
```

<img width="642" alt="Screenshot 2021-06-09 at 09 19 50" src="https://user-images.githubusercontent.com/54427/121320036-b47bda80-c904-11eb-93b3-705985383a95.png">

Notice the `resolve(undefined)` this is added instead of `reject` because `reject` will pop the another error box in addition to `showErrorMessage`


Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>