### PR TITLE
Execution test exceeds call stack size

### DIFF
--- a/test/execution/execution.test.ts
+++ b/test/execution/execution.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as path from 'path';
-import { commands, Uri, window, workspace } from 'vscode';
+import { commands, Selection, Uri, window, workspace } from 'vscode';
 import { GaugeVSCodeCommands } from '../../src/constants';
 import { createSandbox } from 'sinon';
 
@@ -64,8 +64,7 @@ suite('Gauge Execution Tests', () => {
         let doc = await workspace.openTextDocument(specFile);
         await window.showTextDocument(doc);
         await commands.executeCommand("workbench.action.focusFirstEditorGroup");
-        let cm = { to: 'down', by: 'line', value: 8 };
-        await commands.executeCommand("cursorMove", cm);
+        window.activeTextEditor.selection = new Selection(8, 0, 8, 0);
         let status = await commands.executeCommand(GaugeVSCodeCommands.ExecuteScenario);
         assertStatus(status);
     }).timeout(20000);

--- a/test/execution/execution.test.ts
+++ b/test/execution/execution.test.ts
@@ -16,7 +16,6 @@ suite('Gauge Execution Tests', () => {
     setup(async () => {
         sandbox = createSandbox();
         await commands.executeCommand('workbench.action.closeAllEditors');
-        await commands.executeCommand("vscode.openFolder", Uri.file( path.join(__dirname, '..', '..', '..', 'test', 'testdata')));
     });
 
     let assertStatus = (status, val = true) => {


### PR DESCRIPTION
# Avoid exceeding the call stack size

Opening the folder in the test leads to exceeding the call stack size, as shown below.
As far as I can see, all the tests work fine without the line. Is there something I missed?
The line has been added in [this commit](https://github.com/getgauge/gauge-vscode/pull/540/commits/26dc9f68b3aee7f21b516eaf8becffcffe9e88dd#diff-b34366ebbae8aa3582f775836d5fa5b77be1a7a4d1c4655664f56b657284ab43R10).

## Environment

- MacOS BigSur 11.5.2
- VSCode 1.59.0
- Node.js 16.6.1

## Extension host log

```
[2021-08-14 01:03:03.289] [exthost] [error] RangeError: Maximum call stack size exceeded
	at /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:90:6651
	at ReferenceProvider.dispose (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:78:17764)
	at ReferenceProvider.<anonymous> (/Users/atti/Projects/gauge-vscode/out/extension.js:8184:39)
	at ReferenceProvider.dispose (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:78:17808)
	at ReferenceProvider.<anonymous> (/Users/atti/Projects/gauge-vscode/out/extension.js:8184:39)
	at ReferenceProvider.dispose (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:78:17808)
	at ReferenceProvider.<anonymous> (/Users/atti/Projects/gauge-vscode/out/extension.js:8184:39)
	at ReferenceProvider.dispose (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:78:17808)
...
```

## Debug console log

```
(node:27837) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `Code Helper (Renderer) --trace-deprecation ...` to show where the warning was created)

  CLI
    ✓ .isPluginInstalled should tell a gauge plugin is installed or not
    ✓ .getPluginVersion should give version of given plugin
    ✓ .isPluginInstalled should tell a gauge plugin is installed or not
    ✓ .versionString should give its version information as string
    ✓ .versionString should not give commit hash if not available
    ✓ .isVersionGreaterOrEqual should tell if version is greater than orequal with minimum supported gauge version
    ✓ .isVersionGreaterOrEqual should tell if version is lower than minimum supported gauge version
  GaugeClients
    ✓ .get should give the project and client for given project root if exists
    ✓ .get should give the project and client for given file if blongs to a existing project
    ✓ .get should give undefined is the given path does not belong to any project
  GaugeConfig
    ✓ should calculate plugins path for window platform
    ✓ should calculate plugins path for window platform when GAUGE_HOME env is set
    ✓ should calculate plugins path for non window platform
    ✓ should calculate plugins path for non  window platform when GAUGE_HOME env is set
  Gauge Execution Tests
    1) should execute given specification
    2) "after each" hook for "should execute given specification"
  Output Channel
    ✓ should convert specification path from relative to absolute
    ✓ should convert implementation path from relative to absolute
    ✓ should not change implementation path from relative to absolute if it is already absolute
    ✓ should convert implementation path from relative to absolute for lamda methods
    ✓ should convert implementation path from relative to absolute for lamda methods in hooks
  Gauge Extension Tests
    ✓ should activate when manifest file found in path
  ReportEventProcessor
    .process
      ✓ should process a given line text and set report path
      ✓ should not process if line text does not contain the prefix
  DebuggerAttachedEventProcessor
    .process
      ✓ should process a given line text and set the process ID
      ✓ should process a given line text and start debugger
      ✓ should not process if line text does not contain the prefix
  GaugeProject
    .hasFile
      3) should not process if line text does not contain the prefix
Error: Unexpected SIGPIPE
	at process.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/bootstrap.js:1:370)
	at process.emit (events.js:315:20)
	at Signal.callbackTrampoline (internal/async_hooks.js:131:14)
Error: Unexpected SIGPIPE
	at process.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/bootstrap.js:1:370)
	at process.emit (events.js:315:20)
	at Signal.callbackTrampoline (internal/async_hooks.js:131:14)
  25 passing (729ms)
  3 failing
  1) Gauge Execution Tests
       should execute given specification:
     Canceled
   Canceled
  	at Object.i [as canceled] (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:5:1157)
  	at /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:89:8181
  	at Array.forEach (<anonymous>)
  	at h.dispose (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:89:8129)
  	at P.terminate (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:94:684)
  	at h (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:104:32088)
  	at Socket.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:104:29731)
  	at Pipe.<anonymous> (net.js:673:12)
  	at Pipe.callbackTrampoline (internal/async_hooks.js:131:14)

  2) Gauge Execution Tests
       "after each" hook for "should execute given specification":
     Canceled
   Canceled
  	at Object.i [as canceled] (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:5:1157)
  	at h._remoteCall (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:89:12893)
  	at Proxy.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:89:9388)
  	at _doExecuteCommand (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:85:108687)
  	at _.executeCommand (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:85:108233)
  	at Object.executeCommand (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:94:21550)
  	at /Users/atti/Projects/gauge-vscode/out/test/execution/execution.test.js:35:33
  	at Generator.next (<anonymous>)
  	at fulfilled (/Users/atti/Projects/gauge-vscode/out/test/execution/execution.test.js:5:58)
  	at runNextTicks (internal/process/task_queues.js:58:5)
  	at processImmediate (internal/timers.js:434:9)
  	at process.callbackTrampoline (internal/async_hooks.js:131:14)

  3) DebuggerAttachedEventProcessor
       .process
         should not process if line text does not contain the prefix:
     Uncaught Error: write EPIPE
  	at afterWriteDispatched (internal/stream_base_commons.js:156:25)
  	at writeGeneric (internal/stream_base_commons.js:147:3)
  	at Socket._writeGeneric (net.js:785:11)
  	at Socket._write (net.js:797:8)
  	at writeOrBuffer (internal/streams/writable.js:358:12)
  	at Socket.write (internal/streams/writable.js:303:10)
  	at console.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/bootstrap-fork.js:3:727)
  	at Function.consoleLog (/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/microsoft-authentication/dist/extension.js:1:137893)
  	at processImmediate (internal/timers.js:461:21)
  	at process.callbackTrampoline (internal/async_hooks.js:131:14)

(node:27909) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `Code Helper (Renderer) --trace-deprecation ...` to show where the warning was created)
```

# Make the cursor movement reproducible

In the original implementation, the cursor is moved 8 lines down from the current position.
However, the initial position of the cursor depends on the previous state of the editor so the cursor will be moved to line 17 on the second run.
In the changed implementation, the cursor will always move to line 9.

# Note

I had to run the `npm run pack` before `Launch Tests` to get the entry point `out/extension.js`.