### PR TITLE
Add Run and Debug buttons to Spec Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
         },
         {
           "command": "gauge.specexplorer.switchProject",
-          "when": "false"
+          "when": "config.noExists"
         },
         {
           "command": "gauge.execute.repeat",
@@ -204,15 +204,15 @@
         },
         {
           "command": "gauge.specexplorer.runAllActiveProjectSpecs",
-          "when": "false"
+          "when": "config.noExists"
         },
         {
           "command": "gauge.specexplorer.runNode",
-          "when": "false"
+          "when": "config.noExists"
         },
         {
           "command": "gauge.specexplorer.debugNode",
-          "when": "false"
+          "when": "config.noExists"
         }
       ],
       "view/title": [

--- a/package.json
+++ b/package.json
@@ -116,6 +116,18 @@
         }
       },
       {
+        "command": "gauge.specexplorer.runNode",
+        "title": "Run",
+        "category": "Gauge",
+        "icon": "$(debug-start)"
+      },
+      {
+        "command": "gauge.specexplorer.debugNode",
+        "title": "Debug",
+        "category": "Gauge",
+        "icon": "$(bug)"
+      },
+      {
         "command": "gauge.execute.scenario",
         "title": "Run Scenario",
         "category": "Gauge"
@@ -193,6 +205,14 @@
         {
           "command": "gauge.specexplorer.runAllActiveProjectSpecs",
           "when": "false"
+        },
+        {
+          "command": "gauge.specexplorer.runNode",
+          "when": "false"
+        },
+        {
+          "command": "gauge.specexplorer.debugNode",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -205,6 +225,18 @@
           "command": "gauge.specexplorer.runAllActiveProjectSpecs",
           "when": "view == gauge:specExplorer",
           "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "gauge.specexplorer.runNode",
+          "when": "view == gauge:specExplorer",
+          "group": "inline"
+        },
+        {
+          "command": "gauge.specexplorer.debugNode",
+          "when": "view == gauge:specExplorer",
+          "group": "inline"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Gauge support for VScode.",
   "author": "ThoughtWorks",
   "license": "MIT",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "publisher": "getgauge",
   "engines": {
     "vscode": "^1.59.0"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,8 @@ export enum GaugeVSCodeCommands {
     ExecuteSpec = 'gauge.execute.specification',
     ExecuteAllSpecs = 'gauge.execute.specification.all',
     ExecuteAllSpecExplorer = 'gauge.specexplorer.runAllActiveProjectSpecs',
+    ExecuteNode = 'gauge.specexplorer.runNode',
+    DebugNode = 'gauge.specexplorer.debugNode',
     ExecuteScenario = 'gauge.execute.scenario',
     ExecuteScenarios = 'gauge.execute.scenarios',
     GenerateStepStub = 'gauge.generate.step',

--- a/src/execution/debug.ts
+++ b/src/execution/debug.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import getPort = require('get-port');
-import { debug, DebugSession, window, workspace } from 'vscode';
+import { debug, DebugSession, Uri, workspace } from 'vscode';
 import { GaugeRunners } from '../constants';
 import { GaugeClients } from '../gaugeClients';
 import { ExecutionConfig } from './executionConfig';
@@ -135,8 +135,8 @@ export class GaugeDebugger {
 
     public startDebugger() {
         return new Promise((res, rej) => {
-            let folder = workspace.getWorkspaceFolder(window.activeTextEditor.document.uri);
-            let root = this.clientsMap.get(window.activeTextEditor.document.uri.fsPath).project.root();
+            const root = this.config.getProject().root();
+            const folder = workspace.getWorkspaceFolder(Uri.parse(root));
             if (!folder) {
                 throw new Error(`The debugger does not work for a stand alone file. Please open the folder ${root}.`);
             }

--- a/src/execution/lineProcessors.ts
+++ b/src/execution/lineProcessors.ts
@@ -44,8 +44,8 @@ export class DebuggerAttachedEventProcessor extends BaseProcessor {
     public process(lineText: string, gaugeDebugger: GaugeDebugger): void {
         if (!this.canProcess(lineText)) return;
         gaugeDebugger.addProcessId(+lineText.replace(/^\D+/g, ''));
-        gaugeDebugger.startDebugger().catch((reason) => {
-            window.showErrorMessage(reason);
+        gaugeDebugger.startDebugger().catch(error => {
+            window.showErrorMessage(`Failed to start debugger: ${error.message}`);
             this.executor.cancel(false);
         });
     }

--- a/src/explorer/specExplorer.ts
+++ b/src/explorer/specExplorer.ts
@@ -69,7 +69,21 @@ export class SpecNodeProvider extends Disposable implements vscode.TreeDataProvi
                 }),
                 commands.registerCommand(GaugeVSCodeCommands.Open,
                     (node: GaugeNode) => workspace.openTextDocument(node.file)
-                        .then(this.showDocumentWithSelection(node)))
+                        .then(this.showDocumentWithSelection(node))),
+
+                commands.registerCommand(GaugeVSCodeCommands.ExecuteNode, (node: GaugeNode) =>
+                    this.gaugeWorkspace.getGaugeExecutor().execute(
+                        node instanceof Scenario ? node.executionIdentifier : node.file,
+                        new ExecutionConfig().setStatus(node.file)
+                            .setProject(this.gaugeWorkspace.getClientsMap().get(node.file).project))
+                ),
+
+                commands.registerCommand(GaugeVSCodeCommands.DebugNode, (node: GaugeNode) =>
+                    this.gaugeWorkspace.getGaugeExecutor().execute(
+                        node instanceof Scenario ? node.executionIdentifier : node.file,
+                        new ExecutionConfig().setStatus(node.file).setDebug()
+                            .setProject(this.gaugeWorkspace.getClientsMap().get(node.file).project))
+                )
             );
         }
     }


### PR DESCRIPTION
# Summary
Inline Run and Debug buttons in Spec Explorer to run/debug spec/scenario without opening files.
<img width="384" alt="run and debug button in spec explorer" src="https://user-images.githubusercontent.com/18576384/130487371-be24bd62-4503-4cff-8d75-f46aa38a0015.png">

# Discussions
## Test codes
I could not add any tests for this because,
- Debug command tests could not wait for the debugger to detach.
- Scenario node tests will fail or work wrong after pack, because the `Scenario` class in the test code is not the same as the one in `extension.js`.

[Here's what I've done.](https://github.com/at6ue/gauge-vscode/blob/TEST_run-test-explorer-node/test/explorer/specExplorer.test.ts)

## Command contributions
Using `false` on when clause might confuse the parser, but I used `false` to respect the existing implementations.
https://github.com/microsoft/vscode/issues/45119

## Debugger starting failure
I modified `lineProcessor.ts` because I noticed VSCode show nothing there: `window.showErrorMessage` cannot handle `Error` object.
I was confused because the terminal only showed "Success: Tests passed." then. Is it intentional that passing `false` to `executor.cancel` here?