### PR TITLE
Fix file path handling when starting the debugger on Windows file system

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Gauge support for VScode.",
   "author": "ThoughtWorks",
   "license": "MIT",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "publisher": "getgauge",
   "engines": {
     "vscode": "^1.59.0"

--- a/src/execution/debug.ts
+++ b/src/execution/debug.ts
@@ -136,7 +136,7 @@ export class GaugeDebugger {
     public startDebugger() {
         return new Promise((res, rej) => {
             const root = this.config.getProject().root();
-            const folder = workspace.getWorkspaceFolder(Uri.parse(root));
+            const folder = workspace.getWorkspaceFolder(Uri.file(root));
             if (!folder) {
                 throw new Error(`The debugger does not work for a stand alone file. Please open the folder ${root}.`);
             }


### PR DESCRIPTION
Fix issue #726. `Uri.parse` added in #700 should not be used for file paths.
Since the bug affects ALL Windows users, please consider releasing this as soon as possible.