### PR TITLE
Fix file path handling for reports on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Gauge support for VScode.",
   "author": "ThoughtWorks",
   "license": "MIT",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "publisher": "getgauge",
   "engines": {
     "vscode": "^1.59.0"

--- a/src/execution/gaugeExecutor.ts
+++ b/src/execution/gaugeExecutor.ts
@@ -347,10 +347,10 @@ export class GaugeExecutor extends Disposable {
     }
 
     private openReport() {
-        return env.openExternal(Uri.parse(this.gaugeWorkspace.getReportPath())).then(
-        () => { }, (err) => {
-            window.showErrorMessage("Can't open html report. " + err);
-        });
+        return env.openExternal(Uri.file(this.gaugeWorkspace.getReportPath())).then(
+            () => { }, (err) => {
+                window.showErrorMessage("Can't open html report. " + err);
+            });
     }
 
     private registerStopExecution() {


### PR DESCRIPTION
The file path of the report was handled wrongly as in #737.
Nothing has happened when Windows users execute "Show Last Run Report" command or click on the status bar.

`getReportPath` is expected to return only a file path generated by [html-report plugin](https://github.com/getgauge/html-report/blob/baa4f41d192296241ef14b0a1364cb1db80a8d5b/htmlReport.go#L73), as far as I have found.

Only tested manually on Mac OS X and Windows 10.