### PR TITLE
Fix workspace path for testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/node": "^16.9.6",
         "@types/ps-tree": "^1.1.1",
         "@types/vscode": "^1.60.0",
+        "@vscode/test-electron": "^1.6.2",
         "cross-env": "^7.0.3",
         "glob": "^7.1.7",
         "mocha": "^9.1.1",
@@ -34,7 +35,6 @@
         "tslint": "^6.1.3",
         "typescript": "^4.4.3",
         "vsce": "1.100.0",
-        "vscode-test": "^1.6.1",
         "webpack": "5.53.0",
         "webpack-cli": "^4.8.0"
       },
@@ -262,6 +262,21 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "node_modules/@vscode/test-electron": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.2.tgz",
+      "integrity": "sha512-W01ajJEMx6223Y7J5yaajGjVs1QfW3YGkkOJHVKfAMEqNB1ZHN9wCcViehv5ZwVSSJnjhu6lYEYgwBdHtCxqhQ==",
+      "dev": true,
+      "dependencies": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      },
+      "engines": {
+        "node": ">=8.9.3"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -605,9 +620,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "node_modules/big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "version": "1.6.49",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.49.tgz",
+      "integrity": "sha512-KJ7VhqH+f/BOt9a3yMwJNmcZjG53ijWMTjSAGMveQWyLwqIiwkjNP5PFgDob3Snnx86SjDj6I89fIbv0dkQeNw==",
       "dev": true,
       "engines": {
         "node": ">=0.6"
@@ -980,9 +995,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "node_modules/cross-env": {
@@ -3661,21 +3676,6 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
       "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
-    "node_modules/vscode-test": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-      "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-      "dev": true,
-      "dependencies": {
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
-      },
-      "engines": {
-        "node": ">=8.9.3"
-      }
-    },
     "node_modules/watchpack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
@@ -4358,6 +4358,18 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@vscode/test-electron": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.2.tgz",
+      "integrity": "sha512-W01ajJEMx6223Y7J5yaajGjVs1QfW3YGkkOJHVKfAMEqNB1ZHN9wCcViehv5ZwVSSJnjhu6lYEYgwBdHtCxqhQ==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -4641,9 +4653,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "version": "1.6.49",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.49.tgz",
+      "integrity": "sha512-KJ7VhqH+f/BOt9a3yMwJNmcZjG53ijWMTjSAGMveQWyLwqIiwkjNP5PFgDob3Snnx86SjDj6I89fIbv0dkQeNw==",
       "dev": true
     },
     "binary": {
@@ -4936,9 +4948,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "cross-env": {
@@ -6967,18 +6979,6 @@
       "version": "3.16.0",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
       "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-    },
-    "vscode-test": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-      "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
-      }
     },
     "watchpack": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -312,6 +312,7 @@
     "@types/node": "^16.9.6",
     "@types/ps-tree": "^1.1.1",
     "@types/vscode": "^1.60.0",
+    "@vscode/test-electron": "^1.6.2",
     "cross-env": "^7.0.3",
     "glob": "^7.1.7",
     "mocha": "^9.1.1",
@@ -322,7 +323,6 @@
     "tslint": "^6.1.3",
     "typescript": "^4.4.3",
     "vsce": "1.100.0",
-    "vscode-test": "^1.6.1",
     "webpack": "5.53.0",
     "webpack-cli": "^4.8.0"
   },

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -1,7 +1,5 @@
+import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-
-
-import { runTests } from 'vscode-test';
 
 async function go() {
     try {

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -5,12 +5,12 @@ async function go() {
     try {
         const extensionDevelopmentPath = path.resolve(__dirname, '../../');
         const extensionTestsPath = path.resolve(__dirname, './');
-        const testWorkspace = path.resolve(__dirname, './testdata');
+        const testWorkspace = path.resolve(__dirname, '../../test/testdata/sampleProject');
 
         await runTests({
             extensionDevelopmentPath,
             extensionTestsPath,
-            launchArgs: [testWorkspace,'--disable-extensions']
+            launchArgs: [testWorkspace, '--disable-extensions']
         });
 
 


### PR DESCRIPTION
I found that the path to the test workspace was wrong while digging into the cause of test failure in #736.
The failure log was
```
  1) Gauge Execution Tests
       should execute given specification:
     Error: command 'gauge.execute' not found
...
```
This is probably due to the extension not being activated at that time.
`testWorkspace` should be assigned `test/testdata/sampleProject` in order to activate the extension as soon as `manifest.json` is found in the workspace **root**.
I am not sure if this is perfect, but it should improve the test stability.

I also found that `vscode-test` was renamed to `@vscode/test-electron` [from 1.6.2](https://github.com/microsoft/vscode-test/commit/614274c58f9300756209e468fcde566fb452518e#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R2). 
I could not find any official announcement, but [the documentation had already been updated](https://code.visualstudio.com/api/working-with-extensions/testing-extension#migrating-from-vscode).