### PR TITLE
moves client disposal into deactivate method

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Gauge support for VScode.",
   "author": "ThoughtWorks",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "getgauge",
   "engines": {
     "vscode": "^1.63.1"

--- a/src/gaugeWorkspace.ts
+++ b/src/gaugeWorkspace.ts
@@ -30,15 +30,18 @@ const REFERENCE_CONFIG = 'reference';
 export class GaugeWorkspace extends Disposable {
     private readonly _fileProvider: SpecificationProvider;
     private _executor: GaugeExecutor;
-    private _clientsMap: GaugeProjectClientMap = new GaugeProjectClientMap();
+    private _clientsMap: GaugeProjectClientMap;
     private _clientLanguageMap: Map<string, string> = new Map();
     private _outputChannel: OutputChannel = window.createOutputChannel('gauge');
     private _launchConfig: WorkspaceConfiguration;
     private _codeLensConfig: WorkspaceConfiguration;
     private _disposable: Disposable;
     private _specNodeProvider: SpecNodeProvider;
-    constructor(private state: GaugeState, private cli: CLI) {
+
+    constructor(private state: GaugeState, private cli: CLI, clientsMap: GaugeProjectClientMap) {
         super(() => this.dispose());
+
+        this._clientsMap = clientsMap
         this._executor = new GaugeExecutor(this, cli);
 
         if (workspace.workspaceFolders) {
@@ -227,13 +230,5 @@ export class GaugeWorkspace extends Disposable {
         });
     }
 
-    dispose(): Thenable<void> {
-        let promises: Thenable<void>[] = [];
-        for (let cp of this._clientsMap.values()) {
-            promises.push(cp.client.stop());
-        }
-        return Promise.all(promises).then((f) => {
-            this._disposable.dispose();
-        });
-    }
+
 }


### PR DESCRIPTION
Currently, LSP clients are disposed of within `gaugeWorkspace.ts` upon extension disposal.

This doesn't cover all cases and can leave the clients and server running.
I can observe this in our environment where `gauge-vscode` is deployed in a remote development setup. A window reload will dispose of all UI extensions but won't dispose of extensions running in the remote extension host mechanism, these are deactivated. 

The official [multi server LSP example](https://github.com/microsoft/vscode-extension-samples/blob/4721ef0c450f36b5bce2ecd5be4f0352ed9e28ab/lsp-multi-server-sample/client/src/extension.ts#L120) hoists the client map into `extension.ts` and explicitly disposes all resources on deactivation. 

This PR moves to this explicit deactivation strategy.