### PR TITLE
Added setting for config Gauge formatter and send the settings to Gauge server.

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,10 +1,25 @@
 {
-    "autoClosingPairs": [
-        ["<", ">"],
-        ["\"", "\""]
+  "comments": {
+    "lineComment": "//",
+  },
+  "autoClosingPairs": [
+    [
+      "<",
+      ">"
     ],
-    "surroundingPairs": [
-		["<", ">"],
-		["\"", "\""]
+    [
+      "\"",
+      "\""
     ]
+  ],
+  "surroundingPairs": [
+    [
+      "<",
+      ">"
+    ],
+    [
+      "\"",
+      "\""
+    ]
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gauge",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gauge",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@types/fs-extra": "^11.0.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^22.10.10",
+        "@types/node": "^22.13.0",
         "@types/ps-tree": "^1.1.4",
         "@types/sinon": "^17.0.3",
         "@types/vscode": "~1.71.0",
@@ -528,9 +528,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.10.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.10.tgz",
-      "integrity": "sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.0.tgz",
+      "integrity": "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Gauge support for VScode.",
   "author": "ThoughtWorks",
   "license": "MIT",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "publisher": "getgauge",
   "engines": {
     "vscode": "^1.71.0"
@@ -348,6 +348,11 @@
           "type": "string",
           "default": "#228549",
           "description": "Color for disabled steps."
+        },
+        "gauge.formatting.skipEmptyLineInsertions": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, skip adding empty lines during formatting."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -461,7 +461,7 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^22.10.10",
+    "@types/node": "^22.13.0",
     "@types/ps-tree": "^1.1.4",
     "@types/sinon": "^17.0.3",
     "@types/vscode": "~1.71.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Gauge support for VScode.",
   "author": "ThoughtWorks",
   "license": "MIT",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publisher": "getgauge",
   "engines": {
     "vscode": "^1.71.0"
@@ -288,6 +288,66 @@
             "Ignore"
           ],
           "description": "Gauge recommended settings are shown/ignored based on the given value."
+        },
+        "gauge.semanticTokenColors.argument": {
+          "type": "string",
+          "default": "#ae81ff",
+          "description": "Color for arguments."
+        },
+        "gauge.semanticTokenColors.stepMarker": {
+          "type": "string",
+          "default": "#ffffff",
+          "description": "Color for the step marker '*'"
+        },
+        "gauge.semanticTokenColors.step": {
+          "type": "string",
+          "default": "#a6e22e",
+          "description": "Color for step text."
+        },
+        "gauge.semanticTokenColors.table": {
+          "type": "string",
+          "default": "#ae81ff",
+          "description": "Color for table rows (cell data)."
+        },
+        "gauge.semanticTokenColors.tableHeaderSeparator": {
+          "type": "string",
+          "default": "#8349f0",
+          "description": "Color for table separator dashes."
+        },
+        "gauge.semanticTokenColors.tableBorder": {
+          "type": "string",
+          "default": "#8349f0",
+          "description": "Color for table table borders."
+        },
+        "gauge.semanticTokenColors.tagKeyword": {
+          "type": "string",
+          "default": "#ff4689",
+          "description": "Color for tag keywords."
+        },
+        "gauge.semanticTokenColors.tagValue": {
+          "type": "string",
+          "default": "#fc88b2",
+          "description": "Color for tag values."
+        },
+        "gauge.semanticTokenColors.specification": {
+          "type": "string",
+          "default": "#66d9ef",
+          "description": "Color for specification/concept headers."
+        },
+        "gauge.semanticTokenColors.scenario": {
+          "type": "string",
+          "default": "#66d9ef",
+          "description": "Color for scenario headers."
+        },
+        "gauge.semanticTokenColors.comment": {
+          "type": "string",
+          "default": "#cccccc",
+          "description": "Color for comments."
+        },
+        "gauge.semanticTokenColors.disabledStep": {
+          "type": "string",
+          "default": "#228549",
+          "description": "Color for disabled steps."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,57 +1,112 @@
-'use strict';
+    'use strict';
 
-import { debug, ExtensionContext, languages, window, workspace } from 'vscode';
-import { GenerateStubCommandProvider } from './annotator/generateStub';
-import { CLI } from './cli';
-import { ConfigProvider } from './config/configProvider';
-import { ReferenceProvider } from './gaugeReference';
-import { GaugeState } from './gaugeState';
-import { GaugeWorkspace } from './gaugeWorkspace';
-import { ProjectInitializer } from './init/projectInit';
-import { ProjectFactory } from './project/projectFactory';
-import { hasActiveGaugeDocument } from './util';
-import { showInstallGaugeNotification, showWelcomeNotification } from './welcomeNotifications';
-import { GaugeClients as GaugeProjectClientMap } from './gaugeClients';
+    import { debug, ExtensionContext, languages, window, workspace, ConfigurationTarget } from 'vscode';
+    import { GenerateStubCommandProvider } from './annotator/generateStub';
+    import { CLI } from './cli';
+    import { ConfigProvider } from './config/configProvider';
+    import { ReferenceProvider } from './gaugeReference';
+    import { GaugeState } from './gaugeState';
+    import { GaugeWorkspace } from './gaugeWorkspace';
+    import { ProjectInitializer } from './init/projectInit';
+    import { ProjectFactory } from './project/projectFactory';
+    import { hasActiveGaugeDocument } from './util';
+    import { showInstallGaugeNotification, showWelcomeNotification } from './welcomeNotifications';
+    import { GaugeClients as GaugeProjectClientMap } from './gaugeClients';
+    import { GaugeSemanticTokensProvider, legend } from './semanticTokensProvider';
 
-const MINIMUM_SUPPORTED_GAUGE_VERSION = '0.9.6';
+    const MINIMUM_SUPPORTED_GAUGE_VERSION = '0.9.6';
 
-const clientsMap: GaugeProjectClientMap = new GaugeProjectClientMap();
+    const clientsMap: GaugeProjectClientMap = new GaugeProjectClientMap();
 
-export async function activate(context: ExtensionContext) {
-    let cli = CLI.instance();
-    if (!cli) {
-        return;
+    // This function reads Gauge-specific semantic token colors from the configuration
+    // and then updates the editor.semanticTokenColorCustomizations setting.
+    function updateGaugeSemanticTokenColors() {
+        // Read Gauge settings from the gauge configuration section.
+        const gaugeConfig = workspace.getConfiguration("gauge.semanticTokenColors");
+        const colors = {
+            argument: gaugeConfig.get("argument"),
+            stepMarker: gaugeConfig.get("stepMarker"),
+            step: gaugeConfig.get("step"),
+            table: gaugeConfig.get("table"),
+            tableHeaderSeparator: gaugeConfig.get("tableHeaderSeparator"),
+            tableBorder: gaugeConfig.get("tableBorder"),
+            tagKeyword: gaugeConfig.get("tagKeyword"),
+            tagValue: gaugeConfig.get("tagValue"),
+            specification: gaugeConfig.get("specification"),
+            scenario: gaugeConfig.get("scenario"),
+            comment: gaugeConfig.get("comment"),
+            disabledStep: gaugeConfig.get("disabledStep")
+        };
+
+        // Build a new set of semantic token color rules.
+        const semanticTokenRules = {
+            "argument": { "foreground": colors.argument },
+            "stepMarker": { "foreground": colors.stepMarker },
+            "step": { "foreground": colors.step },
+            "table": { "foreground": colors.table },
+            "tableHeaderSeparator": { "foreground": colors.tableHeaderSeparator },
+            "tableBorder": { "foreground": colors.tableBorder },
+            "tagKeyword": { "foreground": colors.tagKeyword },
+            "tagValue": { "foreground": colors.tagValue },
+            "specification": { "foreground": colors.specification },
+            "scenario": { "foreground": colors.scenario },
+            "comment": { "foreground": colors.comment },
+            "disabledStep": { "foreground": colors.disabledStep }
+        };
+
+        // Get the current global editor configuration.
+        const editorConfig = workspace.getConfiguration("editor");
+
+        // Update the semantic token color customizations.
+        editorConfig.update("semanticTokenColorCustomizations", { rules: semanticTokenRules }, ConfigurationTarget.Global);
     }
-    let folders = workspace.workspaceFolders;
-    context.subscriptions.push(new ProjectInitializer(cli));
-    let hasGaugeProject = folders && folders.some((f) => ProjectFactory.isGaugeProject(f.uri.fsPath));
-    if (!hasActiveGaugeDocument(window.activeTextEditor) && !hasGaugeProject) return;
-    if (!cli.isGaugeInstalled() || !cli.isGaugeVersionGreaterOrEqual(MINIMUM_SUPPORTED_GAUGE_VERSION)) {
-        return showInstallGaugeNotification();
-    }
-    showWelcomeNotification(context);
-    languages.setLanguageConfiguration('gauge', { wordPattern: /^(?:[*])([^*].*)$/g });
-    let gaugeWorkspace = new GaugeWorkspace(new GaugeState(context), cli, clientsMap);
 
-    context.subscriptions.push(
-        gaugeWorkspace,
-        new ReferenceProvider(clientsMap),
-        new GenerateStubCommandProvider(clientsMap),
-        new ConfigProvider(context),
-        debug.registerDebugConfigurationProvider('gauge',
-            {
-                resolveDebugConfiguration: () => {
-                    throw Error("Starting with the Gauge debug configuration is not supported. Please use the 'Gauge' commands instead.");
+    export async function activate(context: ExtensionContext) {
+        let cli = CLI.instance();
+        if (!cli) {
+            return;
+        }
+        let folders = workspace.workspaceFolders;
+        context.subscriptions.push(new ProjectInitializer(cli));
+        let hasGaugeProject = folders && folders.some((f) => ProjectFactory.isGaugeProject(f.uri.fsPath));
+        if (!hasActiveGaugeDocument(window.activeTextEditor) && !hasGaugeProject) return;
+        if (!cli.isGaugeInstalled() || !cli.isGaugeVersionGreaterOrEqual(MINIMUM_SUPPORTED_GAUGE_VERSION)) {
+            return showInstallGaugeNotification();
+        }
+        showWelcomeNotification(context);
+        languages.setLanguageConfiguration('gauge', { wordPattern: /^(?:[*])([^*].*)$/g });
+        let gaugeWorkspace = new GaugeWorkspace(new GaugeState(context), cli, clientsMap);
+        updateGaugeSemanticTokenColors();
+
+        context.subscriptions.push(
+            gaugeWorkspace,
+            new ReferenceProvider(clientsMap),
+            new GenerateStubCommandProvider(clientsMap),
+            new ConfigProvider(context),
+            debug.registerDebugConfigurationProvider('gauge',
+                {
+                    resolveDebugConfiguration: () => {
+                        throw Error("Starting with the Gauge debug configuration is not supported. Please use the 'Gauge' commands instead.");
+                    }
+                }),
+            languages.registerDocumentSemanticTokensProvider(
+                { language: 'gauge' },
+                new GaugeSemanticTokensProvider(),
+                legend
+            ),
+            workspace.onDidChangeConfiguration((e) => {
+                if (e.affectsConfiguration("gauge.semanticTokenColors")) {
+                    updateGaugeSemanticTokenColors();
                 }
             })
-    );
-}
-
-export function deactivate(): Thenable<void> {
-    const promises: Thenable<void>[] = [];
-
-    for (const {client} of clientsMap.values()) {
-        promises.push(client.stop());
+        );
     }
-    return Promise.all(promises).then(() => undefined);
-}
+
+    export function deactivate(): Thenable<void> {
+        const promises: Thenable<void>[] = [];
+
+        for (const { client } of clientsMap.values()) {
+            promises.push(client.stop());
+        }
+        return Promise.all(promises).then(() => undefined);
+    }

--- a/src/gaugeWorkspace.ts
+++ b/src/gaugeWorkspace.ts
@@ -169,7 +169,6 @@ export class GaugeWorkspace extends Disposable {
             synchronize: {
                 configurationSection: 'gauge'
             },
-
         };
         clientOptions.workspaceFolder = workspace.getWorkspaceFolder(Uri.file(folder));
         let languageClient = new LanguageClient('gauge', 'Gauge', serverOptions, clientOptions);
@@ -233,6 +232,4 @@ export class GaugeWorkspace extends Disposable {
             }
         });
     }
-
-
 }

--- a/src/gaugeWorkspace.ts
+++ b/src/gaugeWorkspace.ts
@@ -166,6 +166,10 @@ export class GaugeWorkspace extends Disposable {
             diagnosticCollectionName: 'gauge',
             outputChannel: this._outputChannel,
             revealOutputChannelOn: RevealOutputChannelOn.Never,
+            synchronize: {
+                configurationSection: 'gauge'
+            },
+
         };
         clientOptions.workspaceFolder = workspace.getWorkspaceFolder(Uri.file(folder));
         let languageClient = new LanguageClient('gauge', 'Gauge', serverOptions, clientOptions);

--- a/src/semanticTokensProvider.ts
+++ b/src/semanticTokensProvider.ts
@@ -1,0 +1,185 @@
+import * as vscode from 'vscode';
+
+const tokenTypes = [
+  'specification',            // For spec/concept headers: lines starting with '#' or underlined with '='
+  'scenario',                 // For scenario headers: lines starting with '##' or underlined with '-'
+  'stepMarker',               // For the leading "*" in a step line
+  'step',                     // For the rest of the step text
+  'argument',                 // For any quoted text or angle-bracketed text in step lines (or concept heading)
+  'table',                    // For table cell text (non-border, non-separator)
+  'tableHeaderSeparator',     // For table header separator dash characters (only '-' characters)
+  'tableBorder',              // For table border characters (the '|' characters)
+  'tagKeyword',               // For the literal "tags:" at the beginning of a tag line
+  'tagValue',                 // For the remainder of a tag line after "tags:"
+  'disabledStep',             // For lines starting with "//" (used to disable a step)
+  'comment'                   // For lines that do not match any of the above (fallback comment lines)
+];
+const tokenModifiers: string[] = [];
+export const legend = new vscode.SemanticTokensLegend(tokenTypes, tokenModifiers);
+
+export class GaugeSemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
+  public provideDocumentSemanticTokens(
+    document: vscode.TextDocument,
+    token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.SemanticTokens> {
+    const builder = new vscode.SemanticTokensBuilder(legend);
+    const lines = document.getText().split(/\r?\n/);
+
+    // Combined regular expression to match text within double quotes OR within angle brackets.
+    const argumentRegex = /(?:"([^"]+)"|<([^>]+)>)/g;
+    // Regular expression to detect a table header separator line.
+    // Matches lines that start and end with a pipe and contain only dashes, pipes, and optional spaces.
+    const tableHeaderSeparatorRegex = /^\|\s*-+\s*(\|\s*-+\s*)+\|?$/;
+
+    // Process the document with a manual loop (to allow multi‑line heading handling).
+    for (let i = 0; i < lines.length;) {
+      const line = lines[i];
+      const trimmedLine = line.trim();
+
+      // 0. Check for comment lines - lines starting with "//"
+      if (trimmedLine.startsWith("//")) {
+        builder.push(i, 0, line.length, tokenTypes.indexOf('disabledStep'), 0);
+        i++;
+        continue;
+      }
+
+      // 1. Check for underlined headings:
+      // If the next line exists and is made up entirely of "=" then this is a specification header.
+      if (i + 1 < lines.length) {
+        const nextLine = lines[i + 1];
+        const trimmedNextLine = nextLine.trim();
+        if (trimmedNextLine.length > 0 && /^[=]+$/.test(trimmedNextLine)) {
+          const leadingSpaces = line.length - line.trimStart().length;
+          // Mark the heading line.
+          builder.push(i, leadingSpaces, line.length - leadingSpaces, tokenTypes.indexOf('specification'), 0);
+          // Mark the underline line.
+          builder.push(i + 1, 0, nextLine.length, tokenTypes.indexOf('specification'), 0);
+          i += 2;
+          continue;
+        }
+        // If the next line is made up entirely of "-" then this is a scenario header.
+        if (trimmedNextLine.length > 0 && /^[-]+$/.test(trimmedNextLine)) {
+          const leadingSpaces = line.length - line.trimStart().length;
+          builder.push(i, leadingSpaces, line.length - leadingSpaces, tokenTypes.indexOf('scenario'), 0);
+          builder.push(i + 1, 0, nextLine.length, tokenTypes.indexOf('scenario'), 0);
+          i += 2;
+          continue;
+        }
+      }
+
+      // 2. Check for '#' style headings.
+      // Now we process any heading line that starts with '#' to also highlight arguments.
+      if (trimmedLine.startsWith("#")) {
+        // Find the first non‑whitespace index.
+        const firstNonWhitespaceIndex = line.search(/\S/);
+        let lastIndex = firstNonWhitespaceIndex;
+        // Reset regex state for this line.
+        argumentRegex.lastIndex = 0;
+        let match: RegExpExecArray | null = argumentRegex.exec(line);
+        while (match !== null) {
+          const matchStart = match.index;
+          if (matchStart > lastIndex) {
+            // Mark the non‑argument portion as a scenario token.
+            builder.push(i, lastIndex, matchStart - lastIndex, tokenTypes.indexOf('scenario'), 0);
+          }
+          // Mark the matched argument text as an argument token.
+          builder.push(i, matchStart, match[0].length, tokenTypes.indexOf('argument'), 0);
+          lastIndex = argumentRegex.lastIndex;
+          match = argumentRegex.exec(line);
+        }
+        if (lastIndex < line.length) {
+          builder.push(i, lastIndex, line.length - lastIndex, tokenTypes.indexOf('scenario'), 0);
+        }
+        i++;
+        continue;
+      }
+
+      // 3. Check for tag lines (lines starting with "tags:" case-insensitively).
+      else if (trimmedLine.toLowerCase().startsWith('tags:')) {
+        const leadingSpaces = line.length - line.trimStart().length;
+        const keyword = "tags:";
+        builder.push(i, leadingSpaces, keyword.length, tokenTypes.indexOf('tagKeyword'), 0);
+        const tagValueStart = leadingSpaces + keyword.length;
+        if (tagValueStart < line.length) {
+          builder.push(i, tagValueStart, line.length - tagValueStart, tokenTypes.indexOf('tagValue'), 0);
+        }
+        i++;
+        continue;
+      }
+
+      // 4. Process step lines (lines starting with '*').
+      else if (trimmedLine.startsWith('*')) {
+        const firstNonWhitespaceIndex = line.indexOf('*');
+        if (firstNonWhitespaceIndex !== -1) {
+          // Mark the "*" as a stepMarker.
+          builder.push(i, firstNonWhitespaceIndex, 1, tokenTypes.indexOf('stepMarker'), 0);
+          let lastIndex = firstNonWhitespaceIndex + 1;
+          // Reset regex state for this line.
+          argumentRegex.lastIndex = 0;
+          let match: RegExpExecArray | null = argumentRegex.exec(line);
+          while (match !== null) {
+            const matchStart = match.index;
+            if (matchStart > lastIndex) {
+              builder.push(i, lastIndex, matchStart - lastIndex, tokenTypes.indexOf('step'), 0);
+            }
+            // Mark the entire matched text (including quotes or angle brackets) as an argument.
+            builder.push(i, matchStart, match[0].length, tokenTypes.indexOf('argument'), 0);
+            lastIndex = argumentRegex.lastIndex;
+            match = argumentRegex.exec(line);
+          }
+          // Any remaining text after the last argument is part of the step.
+          if (lastIndex < line.length) {
+            builder.push(i, lastIndex, line.length - lastIndex, tokenTypes.indexOf('step'), 0);
+          }
+        }
+        i++;
+        continue;
+      }
+
+      // 5. Process table lines (lines starting with '|').
+      else if (trimmedLine.startsWith('|')) {
+        if (tableHeaderSeparatorRegex.test(trimmedLine)) {
+          // Process the table separator line character-by-character.
+          for (let j = 0; j < line.length; j++) {
+            const char = line[j];
+            if (char === '|') {
+              // Mark pipe characters as tableBorder.
+              builder.push(i, j, 1, tokenTypes.indexOf('tableBorder'), 0);
+            } else if (char === '-') {
+              let start = j;
+              while (j < line.length && line[j] === '-') {
+                j++;
+              }
+              // Group consecutive dashes as tableHeaderSeparator.
+              builder.push(i, start, j - start, tokenTypes.indexOf('tableHeaderSeparator'), 0);
+              j--; // adjust for outer loop increment
+            } else {
+              // Other characters (likely whitespace) get the "table" token.
+              builder.push(i, j, 1, tokenTypes.indexOf('table'), 0);
+            }
+          }
+        } else {
+          // Process a normal table row character-by-character.
+          for (let j = 0; j < line.length; j++) {
+            const char = line[j];
+            if (char === '|') {
+              builder.push(i, j, 1, tokenTypes.indexOf('tableBorder'), 0);
+            } else {
+              builder.push(i, j, 1, tokenTypes.indexOf('table'), 0);
+            }
+          }
+        }
+        i++;
+        continue;
+      }
+      else {
+        // For any other non-empty line, mark it as a comment.
+        if (trimmedLine.length > 0) {
+          builder.push(i, 0, line.length, tokenTypes.indexOf('comment'), 0);
+        }
+        i++;
+      }
+    }
+    return builder.build();
+  }
+}


### PR DESCRIPTION
@sriv 
1. Added a setting to the Extension called "gauge.formatting.skipEmptyLineInsertions".
2. Added code for sending any "gauge" settings in settings.json to the Gauge server.

For further details:

Issue: https://github.com/getgauge/gauge/issues/2693
Merged PR in Gauge: https://github.com/getgauge/gauge/pull/2692

With the addition one can now control if the formatting of spec-files should add empty lines around "tags" and before "table" entities, (as before) or if you want to disable this when formatting.
