### PR TITLE
Adding syntax highlighting

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,10 +1,25 @@
 {
-    "autoClosingPairs": [
-        ["<", ">"],
-        ["\"", "\""]
+  "comments": {
+    "lineComment": "//",
+  },
+  "autoClosingPairs": [
+    [
+      "<",
+      ">"
     ],
-    "surroundingPairs": [
-		["<", ">"],
-		["\"", "\""]
+    [
+      "\"",
+      "\""
     ]
+  ],
+  "surroundingPairs": [
+    [
+      "<",
+      ">"
+    ],
+    [
+      "\"",
+      "\""
+    ]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -332,7 +332,7 @@
         "gauge.semanticTokenColors.specification": {
           "type": "string",
           "default": "#66d9ef",
-          "description": "Color for specification headers."
+          "description": "Color for specification/concept headers."
         },
         "gauge.semanticTokenColors.scenario": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Gauge support for VScode.",
   "author": "ThoughtWorks",
   "license": "MIT",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publisher": "getgauge",
   "engines": {
     "vscode": "^1.71.0"
@@ -288,6 +288,66 @@
             "Ignore"
           ],
           "description": "Gauge recommended settings are shown/ignored based on the given value."
+        },
+        "gauge.semanticTokenColors.argument": {
+          "type": "string",
+          "default": "#ae81ff",
+          "description": "Color for arguments."
+        },
+        "gauge.semanticTokenColors.stepMarker": {
+          "type": "string",
+          "default": "#ffffff",
+          "description": "Color for the step marker '*'"
+        },
+        "gauge.semanticTokenColors.step": {
+          "type": "string",
+          "default": "#a6e22e",
+          "description": "Color for step text."
+        },
+        "gauge.semanticTokenColors.table": {
+          "type": "string",
+          "default": "#ae81ff",
+          "description": "Color for table rows (cell data)."
+        },
+        "gauge.semanticTokenColors.tableHeaderSeparator": {
+          "type": "string",
+          "default": "#8349f0",
+          "description": "Color for table separator dashes."
+        },
+        "gauge.semanticTokenColors.tableBorder": {
+          "type": "string",
+          "default": "#8349f0",
+          "description": "Color for table table borders."
+        },
+        "gauge.semanticTokenColors.tagKeyword": {
+          "type": "string",
+          "default": "#ff4689",
+          "description": "Color for tag keywords."
+        },
+        "gauge.semanticTokenColors.tagValue": {
+          "type": "string",
+          "default": "#fc88b2",
+          "description": "Color for tag values."
+        },
+        "gauge.semanticTokenColors.specification": {
+          "type": "string",
+          "default": "#66d9ef",
+          "description": "Color for specification headers."
+        },
+        "gauge.semanticTokenColors.scenario": {
+          "type": "string",
+          "default": "#66d9ef",
+          "description": "Color for scenario headers."
+        },
+        "gauge.semanticTokenColors.comment": {
+          "type": "string",
+          "default": "#cccccc",
+          "description": "Color for comments."
+        },
+        "gauge.semanticTokenColors.disabledStep": {
+          "type": "string",
+          "default": "#228549",
+          "description": "Color for disabled steps."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,57 +1,112 @@
-'use strict';
+    'use strict';
 
-import { debug, ExtensionContext, languages, window, workspace } from 'vscode';
-import { GenerateStubCommandProvider } from './annotator/generateStub';
-import { CLI } from './cli';
-import { ConfigProvider } from './config/configProvider';
-import { ReferenceProvider } from './gaugeReference';
-import { GaugeState } from './gaugeState';
-import { GaugeWorkspace } from './gaugeWorkspace';
-import { ProjectInitializer } from './init/projectInit';
-import { ProjectFactory } from './project/projectFactory';
-import { hasActiveGaugeDocument } from './util';
-import { showInstallGaugeNotification, showWelcomeNotification } from './welcomeNotifications';
-import { GaugeClients as GaugeProjectClientMap } from './gaugeClients';
+    import { debug, ExtensionContext, languages, window, workspace, ConfigurationTarget } from 'vscode';
+    import { GenerateStubCommandProvider } from './annotator/generateStub';
+    import { CLI } from './cli';
+    import { ConfigProvider } from './config/configProvider';
+    import { ReferenceProvider } from './gaugeReference';
+    import { GaugeState } from './gaugeState';
+    import { GaugeWorkspace } from './gaugeWorkspace';
+    import { ProjectInitializer } from './init/projectInit';
+    import { ProjectFactory } from './project/projectFactory';
+    import { hasActiveGaugeDocument } from './util';
+    import { showInstallGaugeNotification, showWelcomeNotification } from './welcomeNotifications';
+    import { GaugeClients as GaugeProjectClientMap } from './gaugeClients';
+    import { GaugeSemanticTokensProvider, legend } from './semanticTokensProvider';
 
-const MINIMUM_SUPPORTED_GAUGE_VERSION = '0.9.6';
+    const MINIMUM_SUPPORTED_GAUGE_VERSION = '0.9.6';
 
-const clientsMap: GaugeProjectClientMap = new GaugeProjectClientMap();
+    const clientsMap: GaugeProjectClientMap = new GaugeProjectClientMap();
 
-export async function activate(context: ExtensionContext) {
-    let cli = CLI.instance();
-    if (!cli) {
-        return;
+    // This function reads Gauge-specific semantic token colors from the configuration
+    // and then updates the editor.semanticTokenColorCustomizations setting.
+    function updateGaugeSemanticTokenColors() {
+        // Read Gauge settings from the gauge configuration section.
+        const gaugeConfig = workspace.getConfiguration("gauge.semanticTokenColors");
+        const colors = {
+            argument: gaugeConfig.get("argument"),
+            stepMarker: gaugeConfig.get("stepMarker"),
+            step: gaugeConfig.get("step"),
+            table: gaugeConfig.get("table"),
+            tableHeaderSeparator: gaugeConfig.get("tableHeaderSeparator"),
+            tableBorder: gaugeConfig.get("tableBorder"),
+            tagKeyword: gaugeConfig.get("tagKeyword"),
+            tagValue: gaugeConfig.get("tagValue"),
+            specification: gaugeConfig.get("specification"),
+            scenario: gaugeConfig.get("scenario"),
+            comment: gaugeConfig.get("comment"),
+            disabledStep: gaugeConfig.get("disabledStep")
+        };
+
+        // Build a new set of semantic token color rules.
+        const semanticTokenRules = {
+            "argument": { "foreground": colors.argument },
+            "stepMarker": { "foreground": colors.stepMarker },
+            "step": { "foreground": colors.step },
+            "table": { "foreground": colors.table },
+            "tableHeaderSeparator": { "foreground": colors.tableHeaderSeparator },
+            "tableBorder": { "foreground": colors.tableBorder },
+            "tagKeyword": { "foreground": colors.tagKeyword },
+            "tagValue": { "foreground": colors.tagValue },
+            "specification": { "foreground": colors.specification },
+            "scenario": { "foreground": colors.scenario },
+            "comment": { "foreground": colors.comment },
+            "disabledStep": { "foreground": colors.disabledStep }
+        };
+
+        // Get the current global editor configuration.
+        const editorConfig = workspace.getConfiguration("editor");
+
+        // Update the semantic token color customizations.
+        editorConfig.update("semanticTokenColorCustomizations", { rules: semanticTokenRules }, ConfigurationTarget.Global);
     }
-    let folders = workspace.workspaceFolders;
-    context.subscriptions.push(new ProjectInitializer(cli));
-    let hasGaugeProject = folders && folders.some((f) => ProjectFactory.isGaugeProject(f.uri.fsPath));
-    if (!hasActiveGaugeDocument(window.activeTextEditor) && !hasGaugeProject) return;
-    if (!cli.isGaugeInstalled() || !cli.isGaugeVersionGreaterOrEqual(MINIMUM_SUPPORTED_GAUGE_VERSION)) {
-        return showInstallGaugeNotification();
-    }
-    showWelcomeNotification(context);
-    languages.setLanguageConfiguration('gauge', { wordPattern: /^(?:[*])([^*].*)$/g });
-    let gaugeWorkspace = new GaugeWorkspace(new GaugeState(context), cli, clientsMap);
 
-    context.subscriptions.push(
-        gaugeWorkspace,
-        new ReferenceProvider(clientsMap),
-        new GenerateStubCommandProvider(clientsMap),
-        new ConfigProvider(context),
-        debug.registerDebugConfigurationProvider('gauge',
-            {
-                resolveDebugConfiguration: () => {
-                    throw Error("Starting with the Gauge debug configuration is not supported. Please use the 'Gauge' commands instead.");
+    export async function activate(context: ExtensionContext) {
+        let cli = CLI.instance();
+        if (!cli) {
+            return;
+        }
+        let folders = workspace.workspaceFolders;
+        context.subscriptions.push(new ProjectInitializer(cli));
+        let hasGaugeProject = folders && folders.some((f) => ProjectFactory.isGaugeProject(f.uri.fsPath));
+        if (!hasActiveGaugeDocument(window.activeTextEditor) && !hasGaugeProject) return;
+        if (!cli.isGaugeInstalled() || !cli.isGaugeVersionGreaterOrEqual(MINIMUM_SUPPORTED_GAUGE_VERSION)) {
+            return showInstallGaugeNotification();
+        }
+        showWelcomeNotification(context);
+        languages.setLanguageConfiguration('gauge', { wordPattern: /^(?:[*])([^*].*)$/g });
+        let gaugeWorkspace = new GaugeWorkspace(new GaugeState(context), cli, clientsMap);
+        updateGaugeSemanticTokenColors();
+
+        context.subscriptions.push(
+            gaugeWorkspace,
+            new ReferenceProvider(clientsMap),
+            new GenerateStubCommandProvider(clientsMap),
+            new ConfigProvider(context),
+            debug.registerDebugConfigurationProvider('gauge',
+                {
+                    resolveDebugConfiguration: () => {
+                        throw Error("Starting with the Gauge debug configuration is not supported. Please use the 'Gauge' commands instead.");
+                    }
+                }),
+            languages.registerDocumentSemanticTokensProvider(
+                { language: 'gauge' },
+                new GaugeSemanticTokensProvider(),
+                legend
+            ),
+            workspace.onDidChangeConfiguration((e) => {
+                if (e.affectsConfiguration("gauge.semanticTokenColors")) {
+                    updateGaugeSemanticTokenColors();
                 }
             })
-    );
-}
-
-export function deactivate(): Thenable<void> {
-    const promises: Thenable<void>[] = [];
-
-    for (const {client} of clientsMap.values()) {
-        promises.push(client.stop());
+        );
     }
-    return Promise.all(promises).then(() => undefined);
-}
+
+    export function deactivate(): Thenable<void> {
+        const promises: Thenable<void>[] = [];
+
+        for (const { client } of clientsMap.values()) {
+            promises.push(client.stop());
+        }
+        return Promise.all(promises).then(() => undefined);
+    }

--- a/src/semanticTokensProvider.ts
+++ b/src/semanticTokensProvider.ts
@@ -1,0 +1,169 @@
+import * as vscode from 'vscode';
+
+// Define token types.
+// Order matters: the index in this array is used by the builder.
+const tokenTypes = [
+  'specification',            // For spec headers: lines starting with '#' or underlined with '='
+  'scenario',                 // For scenario headers: lines starting with '##' or underlined with '-'
+  'stepMarker',               // For the leading "*" in a step line
+  'step',                     // For the rest of the step text
+  'argument',                 // For any quoted text or angle-bracketed text in step lines
+  'table',                    // For table cell text (non-border, non-separator)
+  'tableHeaderSeparator',     // For table header separator dash characters (only '-' characters)
+  'tableBorder',              // For table border characters (the '|' characters)
+  'tagKeyword',               // For the literal "tags:" at the beginning of a tag line
+  'tagValue',                 // For the remainder of a tag line after "tags:"
+  'disabledStep',             // For lines starting with "//" (used to disable a step)
+  'comment'                   // For lines that do not match any of the above (fallback comment lines)
+];
+const tokenModifiers: string[] = [];
+export const legend = new vscode.SemanticTokensLegend(tokenTypes, tokenModifiers);
+
+export class GaugeSemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
+  public provideDocumentSemanticTokens(
+    document: vscode.TextDocument,
+    token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.SemanticTokens> {
+    const builder = new vscode.SemanticTokensBuilder(legend);
+    const lines = document.getText().split(/\r?\n/);
+
+    // Combined regular expression to match text within double quotes OR within angle brackets.
+    const argumentRegex = /(?:"([^"]+)"|<([^>]+)>)/g;
+    // Regular expression to detect a table header separator line.
+    // Matches lines that start and end with a pipe and contain only dashes, pipes, and optional spaces.
+    const tableHeaderSeparatorRegex = /^\|\s*-+\s*(\|\s*-+\s*)+\|?$/;
+
+    // Process the document with a manual loop (to allow multi‑line heading handling).
+    for (let i = 0; i < lines.length;) {
+      const line = lines[i];
+      const trimmedLine = line.trim();
+
+      // 0. Check for comment lines - lines starting with "//"
+      if (trimmedLine.startsWith("//")) {
+        builder.push(i, 0, line.length, tokenTypes.indexOf('disabledStep'), 0);
+        i++;
+        continue;
+      }
+
+      // 1. Check for underlined headings:
+      // If the next line exists and is made up entirely of "=" then this is a specification header.
+      if (i + 1 < lines.length) {
+        const nextLine = lines[i + 1];
+        const trimmedNextLine = nextLine.trim();
+        if (trimmedNextLine.length > 0 && /^[=]+$/.test(trimmedNextLine)) {
+          const leadingSpaces = line.length - line.trimStart().length;
+          // Mark the heading line.
+          builder.push(i, leadingSpaces, line.length - leadingSpaces, tokenTypes.indexOf('specification'), 0);
+          // Mark the underline line.
+          builder.push(i + 1, 0, nextLine.length, tokenTypes.indexOf('specification'), 0);
+          i += 2;
+          continue;
+        }
+        // If the next line is made up entirely of "-" then this is a scenario header.
+        if (trimmedNextLine.length > 0 && /^[-]+$/.test(trimmedNextLine)) {
+          const leadingSpaces = line.length - line.trimStart().length;
+          builder.push(i, leadingSpaces, line.length - leadingSpaces, tokenTypes.indexOf('scenario'), 0);
+          builder.push(i + 1, 0, nextLine.length, tokenTypes.indexOf('scenario'), 0);
+          i += 2;
+          continue;
+        }
+      }
+
+      // 2. Check for '#' style headings.
+      // Check for "##" first.
+      if (trimmedLine.startsWith("##")) {
+        const leadingSpaces = line.length - line.trimStart().length;
+        builder.push(i, leadingSpaces, line.length - leadingSpaces, tokenTypes.indexOf('scenario'), 0);
+        i++;
+        continue;
+      } else if (trimmedLine.startsWith("#")) {
+        const leadingSpaces = line.length - line.trimStart().length;
+        builder.push(i, leadingSpaces, line.length - leadingSpaces, tokenTypes.indexOf('specification'), 0);
+        i++;
+        continue;
+      }
+      // 3. Check for tag lines (lines starting with "tags:" case-insensitively).
+      else if (trimmedLine.toLowerCase().startsWith('tags:')) {
+        const leadingSpaces = line.length - line.trimStart().length;
+        const keyword = "tags:";
+        builder.push(i, leadingSpaces, keyword.length, tokenTypes.indexOf('tagKeyword'), 0);
+        const tagValueStart = leadingSpaces + keyword.length;
+        if (tagValueStart < line.length) {
+          builder.push(i, tagValueStart, line.length - tagValueStart, tokenTypes.indexOf('tagValue'), 0);
+        }
+        i++;
+        continue;
+      }
+      // 4. Process step lines (lines starting with '*').
+      else if (trimmedLine.startsWith('*')) {
+        const firstNonWhitespaceIndex = line.indexOf('*');
+        if (firstNonWhitespaceIndex !== -1) {
+          // Mark the "*" as a stepMarker.
+          builder.push(i, firstNonWhitespaceIndex, 1, tokenTypes.indexOf('stepMarker'), 0);
+          let lastIndex = firstNonWhitespaceIndex + 1;
+          let match: RegExpExecArray | null;
+          // Use the combined regex to capture both quoted and angle-bracketed arguments.
+          while ((match = argumentRegex.exec(line)) !== null) {
+            const matchStart = match.index;
+            if (matchStart > lastIndex) {
+              builder.push(i, lastIndex, matchStart - lastIndex, tokenTypes.indexOf('step'), 0);
+            }
+            // Mark the entire matched text (including quotes or angle brackets) as an argument.
+            builder.push(i, matchStart, match[0].length, tokenTypes.indexOf('argument'), 0);
+            lastIndex = argumentRegex.lastIndex;
+          }
+          // Any remaining text after the last argument is part of the step.
+          if (lastIndex < line.length) {
+            builder.push(i, lastIndex, line.length - lastIndex, tokenTypes.indexOf('step'), 0);
+          }
+        }
+        i++;
+        continue;
+      }
+      // 5. Process table lines (lines starting with '|').
+      else if (trimmedLine.startsWith('|')) {
+        if (tableHeaderSeparatorRegex.test(trimmedLine)) {
+          // Process the table separator line character-by-character.
+          for (let j = 0; j < line.length; j++) {
+            const char = line[j];
+            if (char === '|') {
+              // Mark pipe characters as tableBorder.
+              builder.push(i, j, 1, tokenTypes.indexOf('tableBorder'), 0);
+            } else if (char === '-') {
+              let start = j;
+              while (j < line.length && line[j] === '-') {
+                j++;
+              }
+              // Group consecutive dashes as tableHeaderSeparator.
+              builder.push(i, start, j - start, tokenTypes.indexOf('tableHeaderSeparator'), 0);
+              j--; // adjust for outer loop increment
+            } else {
+              // Other characters (likely whitespace) get the "table" token.
+              builder.push(i, j, 1, tokenTypes.indexOf('table'), 0);
+            }
+          }
+        } else {
+          // Process a normal table row character-by-character.
+          for (let j = 0; j < line.length; j++) {
+            const char = line[j];
+            if (char === '|') {
+              builder.push(i, j, 1, tokenTypes.indexOf('tableBorder'), 0);
+            } else {
+              builder.push(i, j, 1, tokenTypes.indexOf('table'), 0);
+            }
+          }
+        }
+        i++;
+        continue;
+      }
+      else {
+        // For any other non-empty line, mark it as a comment.
+        if (trimmedLine.length > 0) {
+          builder.push(i, 0, line.length, tokenTypes.indexOf('comment'), 0);
+        }
+        i++;
+      }
+    }
+    return builder.build();
+  }
+}

--- a/src/semanticTokensProvider.ts
+++ b/src/semanticTokensProvider.ts
@@ -99,9 +99,9 @@ export class GaugeSemanticTokensProvider implements vscode.DocumentSemanticToken
           // Mark the "*" as a stepMarker.
           builder.push(i, firstNonWhitespaceIndex, 1, tokenTypes.indexOf('stepMarker'), 0);
           let lastIndex = firstNonWhitespaceIndex + 1;
-          let match: RegExpExecArray | null;
           // Use the combined regex to capture both quoted and angle-bracketed arguments.
-          while ((match = argumentRegex.exec(line)) !== null) {
+          let match: RegExpExecArray | null = argumentRegex.exec(line);
+          while (match !== null) {
             const matchStart = match.index;
             if (matchStart > lastIndex) {
               builder.push(i, lastIndex, matchStart - lastIndex, tokenTypes.indexOf('step'), 0);
@@ -109,6 +109,7 @@ export class GaugeSemanticTokensProvider implements vscode.DocumentSemanticToken
             // Mark the entire matched text (including quotes or angle brackets) as an argument.
             builder.push(i, matchStart, match[0].length, tokenTypes.indexOf('argument'), 0);
             lastIndex = argumentRegex.lastIndex;
+            match = argumentRegex.exec(line);
           }
           // Any remaining text after the last argument is part of the step.
           if (lastIndex < line.length) {

--- a/src/semanticTokensProvider.ts
+++ b/src/semanticTokensProvider.ts
@@ -1,7 +1,5 @@
 import * as vscode from 'vscode';
 
-// Define token types.
-// Order matters: the index in this array is used by the builder.
 const tokenTypes = [
   'specification',            // For spec headers: lines starting with '#' or underlined with '='
   'scenario',                 // For scenario headers: lines starting with '##' or underlined with '-'


### PR DESCRIPTION
Hi!
@sriv @zabil 
Addressing this issue:
https://github.com/getgauge/gauge-vscode/issues/884

Implemented syntax highlighting. All token-matching is done on extensions side. Extension provides default colors that works fine with VSC default (dark) theme, but can be overridden in settings.json.

Also, during test development I often want to temporarily disable one or multiple steps in a scenario. Although it's not technically markdown I simply put the common "//" in front of the step (and any table) and then the runner ignores it. I've added a binding to VSC short-cut for comment/un-comment that adds "//" at the beginning of the line (which makes it possible to disable many steps quickly my selecting multiple lines). I find it very convenient and I don't see that it does any harm. 

Default look example:

![bild](https://github.com/user-attachments/assets/fca29386-c0ff-4fec-a4db-5436a04df07f)

To override any user can just set their values/colors accordingly:
![bild](https://github.com/user-attachments/assets/39daea50-5850-495a-b8cf-7bbf4534631b)
