### PR TITLE
Bug fix for issue 1042 - Gauge comment syntax highlighter conflicted with default comment highlighter for other langauges.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gauge",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gauge",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Gauge support for VScode.",
   "author": "ThoughtWorks",
   "license": "MIT",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "publisher": "getgauge",
   "engines": {
     "vscode": "^1.71.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@
             "tagValue": { "foreground": colors.tagValue },
             "specification": { "foreground": colors.specification },
             "scenario": { "foreground": colors.scenario },
-            "comment": { "foreground": colors.comment },
+            "gaugeComment": { "foreground": colors.comment },
             "disabledStep": { "foreground": colors.disabledStep }
         };
 

--- a/src/semanticTokensProvider.ts
+++ b/src/semanticTokensProvider.ts
@@ -12,7 +12,7 @@ const tokenTypes = [
   'tagKeyword',               // For the literal "tags:" at the beginning of a tag line
   'tagValue',                 // For the remainder of a tag line after "tags:"
   'disabledStep',             // For lines starting with "//" (used to disable a step)
-  'comment'                   // For lines that do not match any of the above (fallback comment lines)
+  'gaugeComment'              // For lines that do not match any of the above (fallback comment lines)
 ];
 const tokenModifiers: string[] = [];
 export const legend = new vscode.SemanticTokensLegend(tokenTypes, tokenModifiers);
@@ -175,7 +175,7 @@ export class GaugeSemanticTokensProvider implements vscode.DocumentSemanticToken
       else {
         // For any other non-empty line, mark it as a comment.
         if (trimmedLine.length > 0) {
-          builder.push(i, 0, line.length, tokenTypes.indexOf('comment'), 0);
+          builder.push(i, 0, line.length, tokenTypes.indexOf('gaugeComment'), 0);
         }
         i++;
       }


### PR DESCRIPTION
Fix for: https://github.com/getgauge/gauge-vscode/issues/1042

@sriv Please merge when you have time. Sorry for the mistake & inconvenience...