### PR TITLE
fix: Revert addition of visual error when commands cannot be found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gauge",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gauge",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Gauge support for VScode.",
   "author": "ThoughtWorks",
   "license": "MIT",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "getgauge",
   "engines": {
     "vscode": "^1.82.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -121,7 +121,6 @@ export class CLI {
         for (const candidate of this.getCommandCandidates(command)) {
             if (this.checkSpawnable(candidate)) return candidate;
         }
-        window.showErrorMessage(`Unable to find executable launch command: ${command}`);
     }
 
     private static getGradleCommand() {


### PR DESCRIPTION
Didn't pay enough attention to the fact that this is eagerly invoked every time even for maven which many users will neither have nor need; so probably not worth including.

Fixes #1054, partially reverts #1052