### PR TITLE
fix: Correct execing of Maven/Gradle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gauge",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gauge",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Gauge support for VScode.",
   "author": "ThoughtWorks",
   "license": "MIT",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "getgauge",
   "engines": {
     "vscode": "^1.82.0"

--- a/src/project/gradleProject.ts
+++ b/src/project/gradleProject.ts
@@ -24,7 +24,7 @@ export class GradleProject extends GaugeProject {
 
     public envs(cli: CLI): NodeJS.ProcessEnv {
         try {
-            let classpath = execSync(`${cli.gradleCommand()} -q clean classpath`, {cwd: this.root()});
+            let classpath = execSync(`${this.getExecutionCommand(cli)?.command} -q clean classpath`, {cwd: this.root()});
             return {[GAUGE_CUSTOM_CLASSPATH]: classpath.toString().trim() };
         } catch (e) {
             window.showErrorMessage(`Error calculating project classpath.\t\n${e.output.toString()}`);

--- a/src/project/mavenProject.ts
+++ b/src/project/mavenProject.ts
@@ -23,7 +23,7 @@ export class MavenProject extends GaugeProject {
 
     public envs(cli: CLI): NodeJS.ProcessEnv {
         try {
-            let classpath = execSync(`${cli.mavenCommand()} -q gauge:classpath`, {cwd: this.root()});
+            let classpath = execSync(`${this.getExecutionCommand(cli)?.command} -q gauge:classpath`, {cwd: this.root()});
             return {[GAUGE_CUSTOM_CLASSPATH]: classpath.toString().trim() };
         } catch (e) {
             window.showErrorMessage(`Error calculating project classpath.\t\n${e.output.toString()}`);


### PR DESCRIPTION
Fixes #1064

Apparently this similar approach via `execSync` without special options worked earlier, as apparently in NodeJS `exec` seems to always run with a shell even though `spawn` (used to locate the commands) does not.